### PR TITLE
Feature/allergies stu3 review

### DIFF
--- a/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
@@ -21,6 +21,9 @@ package tr.com.srdc.cda2fhir.transform;
  */
 
 import java.io.Serializable;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.hl7.fhir.dstu3.model.Age;
@@ -41,6 +44,7 @@ import org.hl7.fhir.dstu3.model.Composition.DocumentConfidentiality;
 import org.hl7.fhir.dstu3.model.Composition.SectionComponent;
 import org.hl7.fhir.dstu3.model.Condition;
 import org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus;
+import org.hl7.fhir.dstu3.model.DateTimeType;
 import org.hl7.fhir.dstu3.model.DiagnosticReport;
 import org.hl7.fhir.dstu3.model.Encounter;
 import org.hl7.fhir.dstu3.model.Encounter.EncounterParticipantComponent;
@@ -401,6 +405,20 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 						}
 					}
 				}
+			}
+		}
+
+		List<AllergyIntoleranceReactionComponent> reactions = fhirAllergyIntolerance.getReaction();
+		if(reactions != null) {
+			Optional<String> lastOccurance = reactions.stream()
+				.map(r -> r.getOnsetElement())
+				.filter(r -> r != null)
+				.map(r -> r.getValueAsString())
+				.filter(r -> r != null)
+				.max(Comparator.comparing(String::valueOf));
+			if (lastOccurance.isPresent()) {
+				DateTimeType value = new DateTimeType(lastOccurance.get());
+				fhirAllergyIntolerance.setLastOccurrenceElement(value);
 			}
 		}
 		return allergyIntoleranceBundle;

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
@@ -260,14 +260,14 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 			}
 		}
 		
-		// effectiveTime -> onset
+		// effectiveTime -> asserted
 		if(cdaAllergyProbAct.getEffectiveTime() != null && !cdaAllergyProbAct.getEffectiveTime().isSetNullFlavor()) {
 
-			// low(if not exists, value) -> onset
+			// low(if not exists, value) -> asserted
 			if(cdaAllergyProbAct.getEffectiveTime().getLow() != null && !cdaAllergyProbAct.getEffectiveTime().getLow().isSetNullFlavor()) {
-				fhirAllergyIntolerance.setOnset(dtt.tTS2DateTime(cdaAllergyProbAct.getEffectiveTime().getLow()));
+				fhirAllergyIntolerance.setAssertedDateElement(dtt.tTS2DateTime(cdaAllergyProbAct.getEffectiveTime().getLow()));
 			} else if(cdaAllergyProbAct.getEffectiveTime().getValue() != null && !cdaAllergyProbAct.getEffectiveTime().getValue().isEmpty()) {
-				fhirAllergyIntolerance.setOnset(dtt.tString2DateTime(cdaAllergyProbAct.getEffectiveTime().getValue()));
+				fhirAllergyIntolerance.setAssertedDateElement(dtt.tString2DateTime(cdaAllergyProbAct.getEffectiveTime().getValue()));
 			}
 		}
 		
@@ -302,6 +302,17 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 									}
 								}
 							}
+						}
+					}
+
+					// effectiveTime -> onset
+					if(cdaAllergyObs.getEffectiveTime() != null && !cdaAllergyObs.getEffectiveTime().isSetNullFlavor()) {
+
+						// low(if not exists, value) -> onset
+						if(cdaAllergyObs.getEffectiveTime().getLow() != null && !cdaAllergyObs.getEffectiveTime().getLow().isSetNullFlavor()) {
+							fhirAllergyIntolerance.setOnset(dtt.tTS2DateTime(cdaAllergyObs.getEffectiveTime().getLow()));
+						} else if(cdaAllergyObs.getEffectiveTime().getValue() != null && !cdaAllergyObs.getEffectiveTime().getValue().isEmpty()) {
+							fhirAllergyIntolerance.setOnset(dtt.tString2DateTime(cdaAllergyObs.getEffectiveTime().getValue()));
 						}
 					}
 

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
@@ -312,7 +312,7 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 								if(entryRelShip.getObservation() != null && !entryRelShip.isSetNullFlavor()) {
 									Observation observation = entryRelShip.getObservation();
 									
-									// status observation
+									// status observation -> clinical status
 									if(observation != null && observation instanceof AllergyStatusObservation) {
 										observation.getValues().stream().filter(value -> value instanceof CE)
 												.map(value -> (CE) value)

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
@@ -277,7 +277,7 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 				if(cdaAllergyObs != null && !cdaAllergyObs.isSetNullFlavor()) {
 
 					
-					// allergyObservation.participant.participantRole.playingEntity.code -> substance
+					// allergyObservation.participant.participantRole.playingEntity.code -> code
 					if(cdaAllergyObs.getParticipants() != null && !cdaAllergyObs.getParticipants().isEmpty()) {
 						for(Participant2 participant : cdaAllergyObs.getParticipants()) {
 							if(participant != null && !participant.isSetNullFlavor()) {

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/ValueSetsTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/ValueSetsTransformerImpl.java
@@ -111,15 +111,12 @@ public class ValueSetsTransformerImpl implements IValueSetsTransformer, Serializ
 			case "418471000":
 				return AllergyIntoleranceCategory.FOOD;
 			case "232347008":
-				return AllergyIntoleranceCategory.ENVIRONMENT;
 			case "420134006":
 			case "418038007":
 			case "419199007": 
-				// TODO: what is correct mapping?
-				//return AllergyIntoleranceCategory.OTHER;
-				//throw new IllegalArgumentException("Unmapped " + cdaAllergyCategoryCode);
-				LOGGER.error("Unmapped {}", cdaAllergyCategoryCode);
+				return AllergyIntoleranceCategory.ENVIRONMENT;
 			default:
+				LOGGER.error("Unmapped allergy category code: {}", cdaAllergyCategoryCode);
 				return null;
 		}
 	}

--- a/src/test/java/tr/com/srdc/cda2fhir/AllergyConcernActTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/AllergyConcernActTest.java
@@ -55,7 +55,7 @@ public class AllergyConcernActTest {
 	private static CDAFactoryImpl cdaFactory;
 	
 	private static Map<String, String> cdaProblemStatusCodeToName = new HashMap<String, String>();
-	private static Map<String, String> cdaAllergyIntolaranceTypeCodeToName = new HashMap<String, String>();
+	private static Map<String, String> cdaAllergyIntoleranceTypeCodeToName = new HashMap<String, String>();
 	
 	private static Map<String, Object> clinicalStatusMap = JsonUtils.filepathToMap("src/test/resources/jolt/value-maps/AllergyIntoleranceClinicalStatus.json");
 	private static Map<String, Object> verificationStatusMap = JsonUtils.filepathToMap("src/test/resources/jolt/value-maps/AllergyIntoleranceVerificationStatus.json");
@@ -73,16 +73,16 @@ public class AllergyConcernActTest {
 		cdaProblemStatusCodeToName.put("73425007", "Inactive");
 		cdaProblemStatusCodeToName.put("413322009", "Resolved");
 		
-		cdaAllergyIntolaranceTypeCodeToName.put("419199007", "Allergy to substance (disorder)");
-		cdaAllergyIntolaranceTypeCodeToName.put("416098002", "Drug allergy (disorder)");
-		cdaAllergyIntolaranceTypeCodeToName.put("59037007", "Drug intolerance (disorder)");		 
-		cdaAllergyIntolaranceTypeCodeToName.put("414285001", "Food allergy (disorder)");
-		cdaAllergyIntolaranceTypeCodeToName.put("235719002", "Food intolerance (disorder)");
-		cdaAllergyIntolaranceTypeCodeToName.put("420134006", "Propensity to adverse reactions (disorder)");
-		cdaAllergyIntolaranceTypeCodeToName.put("419511003", "Propensity to adverse reactions to drug (disorder)");		 
-		cdaAllergyIntolaranceTypeCodeToName.put("418471000", "Propensity to adverse reactions to food (disorder)");
-		cdaAllergyIntolaranceTypeCodeToName.put("418038007", "Propensity to adverse reactions to substance (disorder)");
-		cdaAllergyIntolaranceTypeCodeToName.put("232347008", "Dander (animal) allergy");		
+		cdaAllergyIntoleranceTypeCodeToName.put("419199007", "Allergy to substance (disorder)");
+		cdaAllergyIntoleranceTypeCodeToName.put("416098002", "Drug allergy (disorder)");
+		cdaAllergyIntoleranceTypeCodeToName.put("59037007", "Drug intolerance (disorder)");		 
+		cdaAllergyIntoleranceTypeCodeToName.put("414285001", "Food allergy (disorder)");
+		cdaAllergyIntoleranceTypeCodeToName.put("235719002", "Food intolerance (disorder)");
+		cdaAllergyIntoleranceTypeCodeToName.put("420134006", "Propensity to adverse reactions (disorder)");
+		cdaAllergyIntoleranceTypeCodeToName.put("419511003", "Propensity to adverse reactions to drug (disorder)");		 
+		cdaAllergyIntoleranceTypeCodeToName.put("418471000", "Propensity to adverse reactions to food (disorder)");
+		cdaAllergyIntoleranceTypeCodeToName.put("418038007", "Propensity to adverse reactions to substance (disorder)");
+		cdaAllergyIntoleranceTypeCodeToName.put("232347008", "Dander (animal) allergy");		
 	}
 
 	static private AllergyIntolerance findOneResource(Bundle bundle) throws Exception {
@@ -91,7 +91,7 @@ public class AllergyConcernActTest {
     			.filter(r -> (r instanceof AllergyIntolerance))
     			.map(r -> (AllergyIntolerance) r)
 				.collect(Collectors.toList());
-    	Assert.assertEquals(1, allergyResources.size());
+    	Assert.assertEquals("Multiple AllergyIntolerance resources in the bundle",  1, allergyResources.size());
     	return allergyResources.get(0);	
 	}
 	
@@ -101,7 +101,7 @@ public class AllergyConcernActTest {
 
     	Enumeration<AllergyIntolerance.AllergyIntoleranceCategory> category = allergyIntolerance.getCategory().get(0);
     	String actual = category == null ? null : category.asStringValue();
-		Assert.assertEquals(expected, actual);		
+		Assert.assertEquals("Unexpected AllergyIntolerance category", expected, actual);		
 	}
 	
 	static private AllergyStatusObservationImpl createAllergyStatusObservation(String cdaProblemStatusCode) {
@@ -170,12 +170,12 @@ public class AllergyConcernActTest {
 		
 		DiagnosticChain dxChain = new BasicDiagnostic();
 		Boolean validation = act.validateAllergyProblemActAllergyObservation(dxChain, null);
-		Assert.assertTrue(validation);
+		Assert.assertTrue("Invalid Allergy Problem Act in Test", validation);
 
 		Bundle bundle1 = rt.tAllergyProblemAct2AllergyIntolerance(act);
 		AllergyIntolerance allergyIntolerance1 = findOneResource(bundle1);
 		String actual1 = allergyIntolerance1.getOnsetDateTimeType().getValueAsString();
-		Assert.assertEquals(expected1, actual1.replaceAll("-", ""));
+		Assert.assertEquals("Unexpected AllergyIntolerance OnSet", expected1, actual1.replaceAll("-", ""));
 
 		String expected2 = "20161103";
 		IVL_TS ivlTs2 = cdaTypeFactory.createIVL_TS();
@@ -185,7 +185,7 @@ public class AllergyConcernActTest {
 		Bundle bundle2 = rt.tAllergyProblemAct2AllergyIntolerance(act);
 		AllergyIntolerance allergyIntolerance2 = findOneResource(bundle2);
 		String actual2 = allergyIntolerance2.getOnsetDateTimeType().getValueAsString();
-		Assert.assertEquals(expected2, actual2.replaceAll("-", ""));	
+		Assert.assertEquals("Unexpected AllergyIntolerance OnSet", expected2, actual2.replaceAll("-", ""));	
 	}
 	
 	@Test
@@ -209,15 +209,15 @@ public class AllergyConcernActTest {
 	
 		DiagnosticChain dxChain = new BasicDiagnostic();
 		Boolean validation = act.validateAllergyProblemActAllergyObservation(dxChain, null);
-		Assert.assertTrue(validation);
+		Assert.assertTrue("Invalid Allergy Problem Act in Test", validation);
 
 		Bundle bundle = rt.tAllergyProblemAct2AllergyIntolerance(act);
 		AllergyIntolerance allergyIntolerance = findOneResource(bundle);
 		CodeableConcept cc = allergyIntolerance.getCode();
 		Coding coding = cc.getCoding().get(0);
 		
-		Assert.assertEquals("2670", coding.getCode());
-		Assert.assertEquals("Codeine", coding.getDisplay());
+		Assert.assertEquals("Unexpected AllergyIntolerance code value", "2670", coding.getCode());
+		Assert.assertEquals("Unexpected AllergyIntolerance code display value", "Codeine", coding.getDisplay());
 	}
 		
 	@Test
@@ -229,7 +229,7 @@ public class AllergyConcernActTest {
 		for (Map.Entry<String, Object> entry : categoryMap.entrySet()) {
 			String cdaType = entry.getKey();
 			String fhirCategory = (String) entry.getValue();
-			String cdaTypeName = cdaAllergyIntolaranceTypeCodeToName.get(cdaType);
+			String cdaTypeName = cdaAllergyIntoleranceTypeCodeToName.get(cdaType);
 
 			CE ce = cdaTypeFactory.createCE (cdaType, "2.16.840.1.11388 3.6.96", "SNOMED CT", cdaTypeName);
 
@@ -238,7 +238,7 @@ public class AllergyConcernActTest {
 			
 			DiagnosticChain dxChain = new BasicDiagnostic();
 			Boolean validation = act.validateAllergyProblemActAllergyObservation(dxChain, null);
-			Assert.assertTrue(validation);
+			Assert.assertTrue("Invalid Allergy Problem Act in Test", validation);
 			
 			verifyAllergyIntoleranceCategory(act, fhirCategory);
 		}
@@ -262,13 +262,13 @@ public class AllergyConcernActTest {
 										
 			DiagnosticChain dxChain = new BasicDiagnostic();
 			Boolean validation = act.validateAllergyProblemActAllergyObservation(dxChain, null);
-			Assert.assertTrue(validation);
+			Assert.assertTrue("Invalid Allergy Problem Act in Test", validation);
 	
 			Bundle bundle = rt.tAllergyProblemAct2AllergyIntolerance(act);
 			AllergyIntolerance allergyIntolerance = findOneResource(bundle);
 			AllergyIntoleranceClinicalStatus clinicalStatus = allergyIntolerance.getClinicalStatus();
 			String actual = clinicalStatus.toCode();
-			Assert.assertEquals(fhirClinicalStatus, actual);
+			Assert.assertEquals("Unexpected AllergtIntolerance Clinical Status", fhirClinicalStatus, actual);
 		}
 	}
 
@@ -311,7 +311,7 @@ public class AllergyConcernActTest {
 		
 		DiagnosticChain dxChain = new BasicDiagnostic();
 		Boolean validation = act.validateAllergyProblemActAllergyObservation(dxChain, null);
-		Assert.assertTrue(validation);		
+		Assert.assertTrue("Invalid Allergy Problem Act in Test", validation);		
 
 		Bundle bundle = rt.tAllergyProblemAct2AllergyIntolerance(act);
 		AllergyIntolerance allergyIntolerance = findOneResource(bundle);
@@ -323,11 +323,11 @@ public class AllergyConcernActTest {
 		String actual1 = reaction1.getOnsetElement().getValueAsString();
 		String actual2 = reaction2.getOnsetElement().getValueAsString();
 	
-		Assert.assertEquals(expected1, actual1.replaceAll("-", ""));	
-		Assert.assertEquals(expected2, actual2.replaceAll("-", ""));
+		Assert.assertEquals("Unexpected AllergyIntolerance Reaction Onset value (1):", expected1, actual1.replaceAll("-", ""));	
+		Assert.assertEquals("Unexpected AllergyIntolerance Reaction Onset value (2):", expected2, actual2.replaceAll("-", ""));
 		
 		String lastActual = allergyIntolerance.getLastOccurrenceElement().getValueAsString();
-		Assert.assertEquals(expected2, lastActual.replaceAll("-", ""));
+		Assert.assertEquals("Unexpected AllergyIntolerance Last Occurence:", expected2, lastActual.replaceAll("-", ""));
 	}
 
 	@Test
@@ -340,24 +340,24 @@ public class AllergyConcernActTest {
 		act.setEffectiveTime(ivlTs1);
 		
 		Boolean validation1 = act.validateAllergyProblemActEffectiveTime(dxChain, null);
-		Assert.assertTrue(validation1);
+		Assert.assertTrue("Invalid Allergy Problem Act in Test", validation1);
 
 		Bundle bundle1 = rt.tAllergyProblemAct2AllergyIntolerance(act);
 		AllergyIntolerance allergyIntolerance1 = findOneResource(bundle1);
 		String actual1 = allergyIntolerance1.getAssertedDateElement().getValueAsString();
-		Assert.assertEquals(expected1, actual1.replaceAll("-", ""));
+		Assert.assertEquals("Unexpected AllergyIntolerance Asserted Date (1)", expected1, actual1.replaceAll("-", ""));
 
 		String expected2 = "20161103";
 		IVL_TS ivlTs2 = createEffectiveTimeValue(expected2);
 		act.setEffectiveTime(ivlTs2);
 
 		Boolean validation2 = act.validateAllergyProblemActEffectiveTime(dxChain, null);
-		Assert.assertTrue(validation2);
+		Assert.assertTrue("Invalid Allergy Problem Act in Test", validation2);
 				
 		Bundle bundle2 = rt.tAllergyProblemAct2AllergyIntolerance(act);
 		AllergyIntolerance allergyIntolerance2 = findOneResource(bundle2);
 		String actual2 = allergyIntolerance2.getAssertedDateElement().getValueAsString();
-		Assert.assertEquals(expected2, actual2.replaceAll("-", ""));	
+		Assert.assertEquals("Unexpected AllergyIntolerance Asserted Date (2)", expected2, actual2.replaceAll("-", ""));	
 	}
 		
 	static private void verifyAllergyIntoleranceVerificationStatus(AllergyProblemAct act, String expected) throws Exception {
@@ -383,7 +383,7 @@ public class AllergyConcernActTest {
 			
 			CS cs = cdaTypeFactory.createCS(cdaStatusCode);
 			act.setStatusCode(cs);
-			Assert.assertTrue(act.validateAllergyProblemActStatusCode(null, null));
+			Assert.assertTrue("Invalid Allergy Problem Act in Test", act.validateAllergyProblemActStatusCode(null, null));
 
 			verifyAllergyIntoleranceVerificationStatus(act, fhirStatus);
 		}

--- a/src/test/java/tr/com/srdc/cda2fhir/AllergyConcernActTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/AllergyConcernActTest.java
@@ -279,6 +279,12 @@ public class AllergyConcernActTest {
 		ivlTs.setLow(ivxb);
 		return ivlTs;
 	}
+
+	static private IVL_TS createEffectiveTimeValue(String value) {
+		IVL_TS ivlTs = cdaTypeFactory.createIVL_TS();
+		ivlTs.setValue(value);
+		return ivlTs; 
+	}
 	
 	@Test
 	public void testReactionObservationEffectiveTime() throws Exception {
@@ -323,8 +329,37 @@ public class AllergyConcernActTest {
 		String lastActual = allergyIntolerance.getLastOccurrenceElement().getValueAsString();
 		Assert.assertEquals(expected2, lastActual.replaceAll("-", ""));
 	}
-	
-	
+
+	@Test
+	public void testEffectiveTime() throws Exception {
+		AllergyProblemActImpl act = createAllergyConcernAct();
+		DiagnosticChain dxChain = new BasicDiagnostic();
+
+		String expected1 = "20171002";		
+		IVL_TS ivlTs1 = createEffectiveTimeLow(expected1);
+		act.setEffectiveTime(ivlTs1);
+		
+		Boolean validation1 = act.validateAllergyProblemActEffectiveTime(dxChain, null);
+		Assert.assertTrue(validation1);
+
+		Bundle bundle1 = rt.tAllergyProblemAct2AllergyIntolerance(act);
+		AllergyIntolerance allergyIntolerance1 = findOneResource(bundle1);
+		String actual1 = allergyIntolerance1.getAssertedDateElement().getValueAsString();
+		Assert.assertEquals(expected1, actual1.replaceAll("-", ""));
+
+		String expected2 = "20161103";
+		IVL_TS ivlTs2 = createEffectiveTimeValue(expected2);
+		act.setEffectiveTime(ivlTs2);
+
+		Boolean validation2 = act.validateAllergyProblemActEffectiveTime(dxChain, null);
+		Assert.assertTrue(validation2);
+				
+		Bundle bundle2 = rt.tAllergyProblemAct2AllergyIntolerance(act);
+		AllergyIntolerance allergyIntolerance2 = findOneResource(bundle2);
+		String actual2 = allergyIntolerance2.getAssertedDateElement().getValueAsString();
+		Assert.assertEquals(expected2, actual2.replaceAll("-", ""));	
+	}
+		
 	static private void verifyAllergyIntoleranceVerificationStatus(AllergyProblemAct act, String expected) throws Exception {
 		Bundle bundle = rt.tAllergyProblemAct2AllergyIntolerance(act);
 		AllergyIntolerance allergyIntolerance = findOneResource(bundle);
@@ -334,34 +369,6 @@ public class AllergyConcernActTest {
 		Assert.assertEquals(expected, actual);		
 	}
 	
-	@Test
-	public void testEffectiveTime() throws Exception {
-		AllergyProblemActImpl act = createAllergyConcernAct();
-
-		String expected1 = "20171002";		
-		IVL_TS ivlTs1 = createEffectiveTimeLow(expected1);
-		act.setEffectiveTime(ivlTs1);
-		
-		DiagnosticChain dxChain = new BasicDiagnostic();
-		Boolean validation = act.validateAllergyProblemActAllergyObservation(dxChain, null);
-		Assert.assertTrue(validation);
-
-		Bundle bundle1 = rt.tAllergyProblemAct2AllergyIntolerance(act);
-		AllergyIntolerance allergyIntolerance1 = findOneResource(bundle1);
-		String actual1 = allergyIntolerance1.getAssertedDateElement().getValueAsString();
-		Assert.assertEquals(expected1, actual1.replaceAll("-", ""));
-
-		String expected2 = "20161103";
-		IVL_TS ivlTs2 = cdaTypeFactory.createIVL_TS();
-		ivlTs2.setValue(expected2);
-		act.setEffectiveTime(ivlTs2);
-		
-		Bundle bundle2 = rt.tAllergyProblemAct2AllergyIntolerance(act);
-		AllergyIntolerance allergyIntolerance2 = findOneResource(bundle2);
-		String actual2 = allergyIntolerance2.getAssertedDateElement().getValueAsString();
-		Assert.assertEquals(expected2, actual2.replaceAll("-", ""));	
-	}
-		
 	@Test
 	public void testAllergyIntoleranceStatusCode() throws Exception {
 		AllergyProblemActImpl act = (AllergyProblemActImpl) cdaObjFactory.createAllergyProblemAct();

--- a/src/test/java/tr/com/srdc/cda2fhir/AllergyConcernActTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/AllergyConcernActTest.java
@@ -374,9 +374,12 @@ public class AllergyConcernActTest {
 		AllergyProblemActImpl act = (AllergyProblemActImpl) cdaObjFactory.createAllergyProblemAct();
 		verifyAllergyIntoleranceVerificationStatus(act, null);
 		
-		act.setStatusCode(cdaTypeFactory.createCS("invalid"));
-		Assert.assertFalse(act.validateAllergyProblemActStatusCode(null, null));
+		act.setStatusCode(null);
+		verifyAllergyIntoleranceVerificationStatus(act, null);
 				
+		act.setStatusCode(cdaTypeFactory.createCS("invalid"));
+		Assert.assertFalse("Unexpected Valid Allergy Problem Act in Test", act.validateAllergyProblemActStatusCode(null, null));		
+		
 		for (Map.Entry<String, Object> entry : verificationStatusMap.entrySet()) {
 			String cdaStatusCode = entry.getKey();
 			String fhirStatus = (String) entry.getValue();

--- a/src/test/java/tr/com/srdc/cda2fhir/AllergyConcernActTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/AllergyConcernActTest.java
@@ -58,6 +58,8 @@ public class AllergyConcernActTest {
 	private static Map<String, String> cdaAllergyIntolaranceTypeCodeToName = new HashMap<String, String>();
 	
 	private static Map<String, Object> clinicalStatusMap = JsonUtils.filepathToMap("src/test/resources/jolt/value-maps/AllergyIntoleranceClinicalStatus.json");
+	private static Map<String, Object> verificationStatusMap = JsonUtils.filepathToMap("src/test/resources/jolt/value-maps/AllergyIntoleranceVerificationStatus.json");
+	private static Map<String, Object> categoryMap = JsonUtils.filepathToMap("src/test/resources/jolt/value-maps/AllergyIntoleranceCategory.json");
 		
 	@BeforeClass
 	public static void init() {
@@ -70,6 +72,17 @@ public class AllergyConcernActTest {
 		cdaProblemStatusCodeToName.put("55561003", "Active");
 		cdaProblemStatusCodeToName.put("73425007", "Inactive");
 		cdaProblemStatusCodeToName.put("413322009", "Resolved");
+		
+		cdaAllergyIntolaranceTypeCodeToName.put("419199007", "Allergy to substance (disorder)");
+		cdaAllergyIntolaranceTypeCodeToName.put("416098002", "Drug allergy (disorder)");
+		cdaAllergyIntolaranceTypeCodeToName.put("59037007", "Drug intolerance (disorder)");		 
+		cdaAllergyIntolaranceTypeCodeToName.put("414285001", "Food allergy (disorder)");
+		cdaAllergyIntolaranceTypeCodeToName.put("235719002", "Food intolerance (disorder)");
+		cdaAllergyIntolaranceTypeCodeToName.put("420134006", "Propensity to adverse reactions (disorder)");
+		cdaAllergyIntolaranceTypeCodeToName.put("419511003", "Propensity to adverse reactions to drug (disorder)");		 
+		cdaAllergyIntolaranceTypeCodeToName.put("418471000", "Propensity to adverse reactions to food (disorder)");
+		cdaAllergyIntolaranceTypeCodeToName.put("418038007", "Propensity to adverse reactions to substance (disorder)");
+		cdaAllergyIntolaranceTypeCodeToName.put("232347008", "Dander (animal) allergy");		
 	}
 
 	static private AllergyIntolerance findOneResource(Bundle bundle) throws Exception {
@@ -213,8 +226,7 @@ public class AllergyConcernActTest {
 		AllergyObservationImpl observationTop = (AllergyObservationImpl) act.getEntryRelationships().get(0).getObservation();					
 		verifyAllergyIntoleranceVerificationStatus(act, null);
 
-		Map<String, Object> map = JsonUtils.filepathToMap("src/test/resources/jolt/value-maps/AllergyIntoleranceCategory.json");
-		for (Map.Entry<String, Object> entry : map.entrySet()) {
+		for (Map.Entry<String, Object> entry : categoryMap.entrySet()) {
 			String cdaType = entry.getKey();
 			String fhirCategory = (String) entry.getValue();
 			String cdaTypeName = cdaAllergyIntolaranceTypeCodeToName.get(cdaType);
@@ -358,8 +370,7 @@ public class AllergyConcernActTest {
 		act.setStatusCode(cdaTypeFactory.createCS("invalid"));
 		Assert.assertFalse(act.validateAllergyProblemActStatusCode(null, null));
 				
-		Map<String, Object> map = JsonUtils.filepathToMap("src/test/resources/jolt/value-maps/AllergyIntoleranceVerificationStatus.json");
-		for (Map.Entry<String, Object> entry : map.entrySet()) {
+		for (Map.Entry<String, Object> entry : verificationStatusMap.entrySet()) {
 			String cdaStatusCode = entry.getKey();
 			String fhirStatus = (String) entry.getValue();
 			

--- a/src/test/java/tr/com/srdc/cda2fhir/AllergyConcernActTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/AllergyConcernActTest.java
@@ -33,6 +33,8 @@ import org.openhealthtools.mdht.uml.hl7.datatypes.CE;
 import org.openhealthtools.mdht.uml.hl7.datatypes.CS;
 import org.openhealthtools.mdht.uml.hl7.datatypes.DatatypesFactory;
 import org.openhealthtools.mdht.uml.hl7.datatypes.II;
+import org.openhealthtools.mdht.uml.hl7.datatypes.IVL_TS;
+import org.openhealthtools.mdht.uml.hl7.datatypes.IVXB_TS;
 import org.openhealthtools.mdht.uml.hl7.datatypes.impl.DatatypesFactoryImpl;
 import org.openhealthtools.mdht.uml.hl7.vocab.EntityClassRoot;
 import org.openhealthtools.mdht.uml.hl7.vocab.ParticipationType;
@@ -137,9 +139,42 @@ public class AllergyConcernActTest {
 
 		return act;
 	}
-		
+
 	@Test
-	public void TestSubstanceReactantForIntolerance() throws Exception {
+	public void testAllergyIntoleranceObservationEffectiveTime() throws Exception {
+		AllergyProblemActImpl act = createAllergyConcernAct();
+		AllergyObservationImpl observation = (AllergyObservationImpl) act.getEntryRelationships().get(0).getObservation();					
+
+		String expected1 = "20171002";
+		
+		IVL_TS ivlTs1 = cdaTypeFactory.createIVL_TS();
+		IVXB_TS ivxb1 = cdaTypeFactory.createIVXB_TS();
+		ivxb1.setValue(expected1);
+		ivlTs1.setLow(ivxb1);
+		observation.setEffectiveTime(ivlTs1);
+		
+		DiagnosticChain dxChain = new BasicDiagnostic();
+		Boolean validation = act.validateAllergyProblemActAllergyObservation(dxChain, null);
+		Assert.assertTrue(validation);
+
+		Bundle bundle1 = rt.tAllergyProblemAct2AllergyIntolerance(act);
+		AllergyIntolerance allergyIntolerance1 = findOneResource(bundle1);
+		String actual1 = allergyIntolerance1.getOnsetDateTimeType().getValueAsString();
+		Assert.assertEquals(expected1, actual1.replaceAll("-", ""));
+
+		String expected2 = "20161103";
+		IVL_TS ivlTs2 = cdaTypeFactory.createIVL_TS();
+		ivlTs2.setValue(expected2);
+		observation.setEffectiveTime(ivlTs2);
+		
+		Bundle bundle2 = rt.tAllergyProblemAct2AllergyIntolerance(act);
+		AllergyIntolerance allergyIntolerance2 = findOneResource(bundle2);
+		String actual2 = allergyIntolerance2.getOnsetDateTimeType().getValueAsString();
+		Assert.assertEquals(expected2, actual2.replaceAll("-", ""));	
+	}
+	
+	@Test
+	public void testSubstanceReactantForIntolerance() throws Exception {
 		AllergyProblemActImpl act = createAllergyConcernAct();
 		AllergyObservationImpl observation = (AllergyObservationImpl) act.getEntryRelationships().get(0).getObservation();					
 		
@@ -233,6 +268,38 @@ public class AllergyConcernActTest {
 		Assert.assertEquals(expected, actual);		
 	}
 	
+	@Test
+	public void testEffectiveTime() throws Exception {
+		AllergyProblemActImpl act = createAllergyConcernAct();
+
+		String expected1 = "20171002";
+		
+		IVL_TS ivlTs1 = cdaTypeFactory.createIVL_TS();
+		IVXB_TS ivxb1 = cdaTypeFactory.createIVXB_TS();
+		ivxb1.setValue(expected1);
+		ivlTs1.setLow(ivxb1);
+		act.setEffectiveTime(ivlTs1);
+		
+		DiagnosticChain dxChain = new BasicDiagnostic();
+		Boolean validation = act.validateAllergyProblemActAllergyObservation(dxChain, null);
+		Assert.assertTrue(validation);
+
+		Bundle bundle1 = rt.tAllergyProblemAct2AllergyIntolerance(act);
+		AllergyIntolerance allergyIntolerance1 = findOneResource(bundle1);
+		String actual1 = allergyIntolerance1.getAssertedDateElement().getValueAsString();
+		Assert.assertEquals(expected1, actual1.replaceAll("-", ""));
+
+		String expected2 = "20161103";
+		IVL_TS ivlTs2 = cdaTypeFactory.createIVL_TS();
+		ivlTs2.setValue(expected2);
+		act.setEffectiveTime(ivlTs2);
+		
+		Bundle bundle2 = rt.tAllergyProblemAct2AllergyIntolerance(act);
+		AllergyIntolerance allergyIntolerance2 = findOneResource(bundle2);
+		String actual2 = allergyIntolerance2.getAssertedDateElement().getValueAsString();
+		Assert.assertEquals(expected2, actual2.replaceAll("-", ""));	
+	}
+		
 	@Test
 	public void testAllergyIntoleranceStatusCode() throws Exception {
 		AllergyProblemActImpl act = (AllergyProblemActImpl) cdaObjFactory.createAllergyProblemAct();

--- a/src/test/resources/jolt/value-maps/AllergyIntoleranceCategory.json
+++ b/src/test/resources/jolt/value-maps/AllergyIntoleranceCategory.json
@@ -1,0 +1,12 @@
+{
+	"416098002": "medication",
+	"59037007": "medication",
+	"419511003": "medication",
+	"414285001": "food",
+	"235719002": "food",
+	"418471000": "food",
+	"232347008": "environment",
+	"420134006": "environment",
+	"418038007": "environment",
+	"419199007": "environment"
+}


### PR DESCRIPTION
#### What does this PR do?

1) Changes “Allergy Concern Act StatusCode” to  “AllergyIntolerance.verificationStatus” mapping and adds unit test.
2) Adds “AllergyIntolerance.ClinicalStatus” implementation by mapping “ProblemStatus” and adds a unit test.
3) Adds “AllergyIntolerance.lastOccurance” implementation by using the latest of reaction onset datetimes and adds a unit test.
4) Changes “AlergyIntolerance.onset” to “AllergyIIntolerance.onsetDatetime”, changes source to “Allergy Concern Observation EffectiveTime” based on descriptions and adds a unit test.
5) Adds “AllergyIntolerance.assertedDate” implementation, uses “Allergy Concern Act EffectiveTime” as source and adds unit test.
6) Adds unit test or “AllergyIntolerance.code”.
7) Changes “AllergyIntolerance.category” mapped values and adds a unit test.
8) Comments a number of tickets as unneeded.

#### Related JIRA tickets:

UPMCFHIR-28
UPMCFHIR-29
UPMCFHIR-30
UPMCFHIR-31
UPMCFHIR-32
UPMCFHIR-33
UPMCFHIR-35
UPMCFHIR-38
UPMCFHIR-40

#### How should this be manually tested?

N/A

#### Background/Context:

AllergyIntolerance resource STU3 first review.

#### New JIRA tickets for clinical review required?

Possibly for UPMCFHIR-29 verificationStatus and UPMCFHIR-30 category.
