### PR TITLE
Location fix

### DIFF
--- a/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
@@ -2257,15 +2257,6 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 		// meta.profile
 		if(Config.isGenerateDafProfileMetadata())
 			fhirLocation.getMeta().addProfile(Constants.PROFILE_DAF_LOCATION);
-		
-		// id -> identifier
-		if(cdaParticipantRole.getIds() != null && !cdaParticipantRole.getIds().isEmpty()) {
-			for(II ii : cdaParticipantRole.getIds()) {
-				if(ii != null && !ii.isSetNullFlavor()) {
-					fhirLocation.addIdentifier(dtt.tII2Identifier(ii));
-				}
-			}
-		}
 
 		// code -> type
 		// TODO: Requires huge mapping work from HL7 HealthcareServiceLocation value set to http://hl7.org/fhir/ValueSet/v3-ServiceDeliveryLocationRoleType

--- a/src/test/java/tr/com/srdc/cda2fhir/LocationTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/LocationTest.java
@@ -35,8 +35,6 @@ import tr.com.srdc.cda2fhir.transform.ResourceTransformerImpl;
 public class LocationTest {
 
     private static final ResourceTransformerImpl rt = new ResourceTransformerImpl();
-
-	private static DatatypesFactory cdaTypeFactory;
 	private static CDAFactoryImpl cdaFactory;
 
     @BeforeClass

--- a/src/test/java/tr/com/srdc/cda2fhir/LocationTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/LocationTest.java
@@ -1,0 +1,67 @@
+package tr.com.srdc.cda2fhir;
+
+/*
+ * #%L
+ * CDA to FHIR Transformer Library
+ * %%
+ * Copyright (C) 2019 Amida Technology Solutions, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.openhealthtools.mdht.uml.cda.impl.ParticipantRoleImpl;
+import org.openhealthtools.mdht.uml.cda.impl.PlayingEntityImpl;
+import org.openhealthtools.mdht.uml.cda.util.CDAUtil;
+import org.openhealthtools.mdht.uml.cda.impl.CDAFactoryImpl;
+import org.openhealthtools.mdht.uml.hl7.datatypes.DatatypesFactory;
+import org.openhealthtools.mdht.uml.hl7.datatypes.impl.DatatypesFactoryImpl;
+import tr.com.srdc.cda2fhir.transform.ResourceTransformerImpl;
+
+public class LocationTest {
+
+    private static final ResourceTransformerImpl rt = new ResourceTransformerImpl();
+
+	private static DatatypesFactory cdaTypeFactory;
+	private static CDAFactoryImpl cdaFactory;
+
+    @BeforeClass
+	public static void init() {
+		CDAUtil.loadPackages();	
+		cdaTypeFactory = DatatypesFactoryImpl.init();		
+		cdaFactory = (CDAFactoryImpl) CDAFactoryImpl.init();		
+    }
+ 
+
+    @Test
+    public void testLocations() throws Exception {
+      
+    	// Make a participant.
+    	ParticipantRoleImpl pr = (ParticipantRoleImpl) cdaFactory.createParticipantRole();
+    	PlayingEntityImpl	pe = (PlayingEntityImpl) cdaFactory.createPlayingEntity();
+    	
+    	pr.setPlayingEntity(pe);
+    	
+        // Transform from CDA to FHIR.
+        org.hl7.fhir.dstu3.model.Location fhirLocation = rt.tParticipantRole2Location(pr);
+
+        Assert.assertEquals("No identifier on FHIR object.",0,fhirLocation.getIdentifier().size());
+        
+    }
+
+
+}

--- a/src/test/java/tr/com/srdc/cda2fhir/LocationTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/LocationTest.java
@@ -30,14 +30,20 @@ import org.openhealthtools.mdht.uml.cda.util.CDAUtil;
 import org.openhealthtools.mdht.uml.cda.impl.CDAFactoryImpl;
 import tr.com.srdc.cda2fhir.transform.ResourceTransformerImpl;
 
+import org.openhealthtools.mdht.uml.hl7.datatypes.DatatypesFactory;
+import org.openhealthtools.mdht.uml.hl7.datatypes.II;
+import org.openhealthtools.mdht.uml.hl7.datatypes.impl.DatatypesFactoryImpl;
+
 public class LocationTest {
 
     private static final ResourceTransformerImpl rt = new ResourceTransformerImpl();
+    private static DatatypesFactory cdaTypeFactory;
 	private static CDAFactoryImpl cdaFactory;
 
     @BeforeClass
 	public static void init() {
 		CDAUtil.loadPackages();			
+		cdaTypeFactory = DatatypesFactoryImpl.init();
 		cdaFactory = (CDAFactoryImpl) CDAFactoryImpl.init();		
     }
  
@@ -48,6 +54,11 @@ public class LocationTest {
     	// Make a participant.
     	ParticipantRoleImpl pr = (ParticipantRoleImpl) cdaFactory.createParticipantRole();
     	PlayingEntityImpl	pe = (PlayingEntityImpl) cdaFactory.createPlayingEntity();
+    	
+    	II identifier = cdaTypeFactory.createII();
+    	identifier.setRoot("sampleRoot");
+
+    	pr.getIds().add(identifier);
     	
     	pr.setPlayingEntity(pe);
     	

--- a/src/test/java/tr/com/srdc/cda2fhir/LocationTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/LocationTest.java
@@ -28,8 +28,6 @@ import org.openhealthtools.mdht.uml.cda.impl.ParticipantRoleImpl;
 import org.openhealthtools.mdht.uml.cda.impl.PlayingEntityImpl;
 import org.openhealthtools.mdht.uml.cda.util.CDAUtil;
 import org.openhealthtools.mdht.uml.cda.impl.CDAFactoryImpl;
-import org.openhealthtools.mdht.uml.hl7.datatypes.DatatypesFactory;
-import org.openhealthtools.mdht.uml.hl7.datatypes.impl.DatatypesFactoryImpl;
 import tr.com.srdc.cda2fhir.transform.ResourceTransformerImpl;
 
 public class LocationTest {
@@ -39,8 +37,7 @@ public class LocationTest {
 
     @BeforeClass
 	public static void init() {
-		CDAUtil.loadPackages();	
-		cdaTypeFactory = DatatypesFactoryImpl.init();		
+		CDAUtil.loadPackages();			
 		cdaFactory = (CDAFactoryImpl) CDAFactoryImpl.init();		
     }
  


### PR DESCRIPTION
#### What does this PR do?

Backs out identifier from location object, also reviews the object for STU3 compliance.  My test doesn't really do anything, but there's no way to set the id on the object before posting it in.

I also ticketed out the location code translation, it's pretty involved if we want to support it.

#### Related JIRA tickets:

UPMCFHIR-138
UPMCFHIR-139
UPMCFHIR-140
UPMCFHIR-206

#### How should this be manually tested?

#### Background/Context:

Needed by encounters so had to make sure we supported it in FHIR.

#### New JIRA tickets for clinical review required?
