### PR TITLE
Upmcfhir 244 remove text

### DIFF
--- a/src/main/java/tr/com/srdc/cda2fhir/conf/Config.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/conf/Config.java
@@ -7,6 +7,7 @@ import org.hl7.fhir.dstu3.model.Composition.CompositionStatus;
 import org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus;
 import org.hl7.fhir.dstu3.model.ContactPoint.ContactPointSystem;
 import org.hl7.fhir.dstu3.model.Encounter.EncounterStatus;
+import org.hl7.fhir.dstu3.model.Identifier.IdentifierUse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +43,7 @@ public class Config {
     public static final String DEFAULT_COMMUNICATION_LANGUAGE_CODE_SYSTEM = "urn:ietf:bcp:47";
     public static final ConditionVerificationStatus DEFAULT_CONDITION_VERIFICATION_STATUS = ConditionVerificationStatus.CONFIRMED;
     public static final CompositionStatus DEFAULT_COMPOSITION_STATUS = CompositionStatus.PRELIMINARY;
+    public static final IdentifierUse DEFAULT_IDENTIFIER_USE = IdentifierUse.OFFICIAL;
     public static final ContactPointSystem DEFAULT_CONTACT_POINT_SYSTEM = ContactPointSystem.PHONE;
     public static final Coding DEFAULT_ENCOUNTER_PARTICIPANT_TYPE_CODE = new Coding().setSystem("http://hl7.org/fhir/v3/ParticipationType").setCode("PART").setDisplay("Participation");
     public static final EncounterStatus DEFAULT_ENCOUNTER_STATUS = EncounterStatus.FINISHED;

--- a/src/main/java/tr/com/srdc/cda2fhir/conf/Config.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/conf/Config.java
@@ -52,7 +52,7 @@ public class Config {
     
     public static final String NARRATIVE_PROPERTIES_FILE_PATH = "file:src/main/resources/narrative/customnarrative.properties";
 
-    private static boolean generateNarrative = true;
+    private static boolean generateNarrative = false;
     private static INarrativeGenerator narrativeGenerator;
 
     private static boolean generateDafProfileMetadata = true;

--- a/src/main/java/tr/com/srdc/cda2fhir/conf/Config.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/conf/Config.java
@@ -79,6 +79,10 @@ public class Config {
         else
             fhirCtx.setNarrativeGenerator(null);
     }
+    
+    public static boolean getGenerateNarrative() {
+       return generateNarrative;
+    }
 
     public static void setGenerateDafProfileMetadata(boolean generateDafProfileMeta) {
         generateDafProfileMetadata = generateDafProfileMeta;

--- a/src/main/java/tr/com/srdc/cda2fhir/conf/Config.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/conf/Config.java
@@ -55,7 +55,7 @@ public class Config {
     private static boolean generateNarrative = false;
     private static INarrativeGenerator narrativeGenerator;
 
-    private static boolean generateDafProfileMetadata = true;
+    private static boolean generateDafProfileMetadata = false;
 
     private static final Logger logger = LoggerFactory.getLogger(Config.class);
 

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/DataTypesTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/DataTypesTransformerImpl.java
@@ -51,6 +51,7 @@ import org.hl7.fhir.dstu3.model.Period;
 import org.hl7.fhir.dstu3.model.Quantity;
 import org.hl7.fhir.dstu3.model.Range;
 import org.hl7.fhir.dstu3.model.Ratio;
+import org.hl7.fhir.dstu3.model.Reference;
 import org.hl7.fhir.dstu3.model.SimpleQuantity;
 import org.hl7.fhir.dstu3.model.StringType;
 import org.hl7.fhir.dstu3.model.Timing;
@@ -517,6 +518,10 @@ public class DataTypesTransformerImpl implements IDataTypesTransformer, Serializ
 		else if(ii.getExtension() != null && !ii.getExtension().isEmpty())
 			identifierDt.setValue(ii.getExtension());
 		
+		if(ii.getAssigningAuthorityName() != null) {
+			identifierDt.setAssigner(new Reference(ii.getAssigningAuthorityName()));
+		}
+			
 		return identifierDt;
 
 	}

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/DataTypesTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/DataTypesTransformerImpl.java
@@ -524,7 +524,9 @@ public class DataTypesTransformerImpl implements IDataTypesTransformer, Serializ
 			identifierDt.setValue(ii.getExtension());
 		
 		if(ii.getAssigningAuthorityName() != null) {
-			identifierDt.setAssigner(new Reference(ii.getAssigningAuthorityName()));
+			Reference ref = new Reference();
+			ref.setDisplay(ii.getAssigningAuthorityName());
+			identifierDt.setAssigner(ref);
 		}
 			
 		return identifierDt;

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/DataTypesTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/DataTypesTransformerImpl.java
@@ -83,7 +83,6 @@ import org.openhealthtools.mdht.uml.hl7.datatypes.SXCM_TS;
 import org.openhealthtools.mdht.uml.hl7.datatypes.TEL;
 import org.openhealthtools.mdht.uml.hl7.datatypes.TS;
 import org.openhealthtools.mdht.uml.hl7.datatypes.URL;
-import org.openhealthtools.mdht.uml.hl7.datatypes.impl.DatatypesFactoryImpl;
 import org.openhealthtools.mdht.uml.hl7.vocab.EntityNameUse;
 import org.openhealthtools.mdht.uml.hl7.vocab.PostalAddressUse;
 import org.openhealthtools.mdht.uml.hl7.vocab.TelecommunicationAddressUse;

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/DataTypesTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/DataTypesTransformerImpl.java
@@ -43,6 +43,7 @@ import org.hl7.fhir.dstu3.model.DateType;
 import org.hl7.fhir.dstu3.model.DecimalType;
 import org.hl7.fhir.dstu3.model.HumanName;
 import org.hl7.fhir.dstu3.model.Identifier;
+import org.hl7.fhir.dstu3.model.Identifier.IdentifierUse;
 import org.hl7.fhir.dstu3.model.InstantType;
 import org.hl7.fhir.dstu3.model.IntegerType;
 import org.hl7.fhir.dstu3.model.Narrative;
@@ -82,6 +83,7 @@ import org.openhealthtools.mdht.uml.hl7.datatypes.SXCM_TS;
 import org.openhealthtools.mdht.uml.hl7.datatypes.TEL;
 import org.openhealthtools.mdht.uml.hl7.datatypes.TS;
 import org.openhealthtools.mdht.uml.hl7.datatypes.URL;
+import org.openhealthtools.mdht.uml.hl7.datatypes.impl.DatatypesFactoryImpl;
 import org.openhealthtools.mdht.uml.hl7.vocab.EntityNameUse;
 import org.openhealthtools.mdht.uml.hl7.vocab.PostalAddressUse;
 import org.openhealthtools.mdht.uml.hl7.vocab.TelecommunicationAddressUse;
@@ -490,9 +492,13 @@ public class DataTypesTransformerImpl implements IDataTypesTransformer, Serializ
 	public Identifier tII2Identifier(II ii) {
 		if(ii == null || ii.isSetNullFlavor())
 			return null;
-		
-		Identifier identifierDt = new Identifier();
 
+		Identifier identifierDt = new Identifier();
+		
+		//default to official use
+		IdentifierUse use = Config.DEFAULT_IDENTIFIER_USE;
+		identifierDt.setUse(use);
+		
 		// if both root and extension are present, then
 		// root -> system
 		// extension -> value

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
@@ -211,7 +211,7 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 		}
 		return null;
 	}
-	
+		
 	public Age tAgeObservation2Age(org.openhealthtools.mdht.uml.cda.consol.AgeObservation cdaAgeObservation) {
 		if(cdaAgeObservation == null || cdaAgeObservation.isSetNullFlavor())
 			return null;
@@ -2796,6 +2796,13 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 			fhirSec.setCode(dtt.tCD2CodeableConcept(cdaSection.getCode()));
 		}
 
+		// text -> text
+		if(cdaSection.getText() != null) {
+			Narrative fhirText = dtt.tStrucDocText2Narrative(cdaSection.getText());
+			if(fhirText != null && Config.getGenerateNarrative())
+				fhirSec.setText(fhirText);
+		}
+
 		return fhirSec;
 	}
 	
@@ -2871,6 +2878,4 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 
 		return result;
 	}
-	
-	
 }

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
@@ -2796,13 +2796,6 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 			fhirSec.setCode(dtt.tCD2CodeableConcept(cdaSection.getCode()));
 		}
 
-		// text -> text
-		if(cdaSection.getText() != null) {
-			Narrative fhirText = dtt.tStrucDocText2Narrative(cdaSection.getText());
-			if(fhirText != null)
-				fhirSec.setText(fhirText);
-		}
-
 		return fhirSec;
 	}
 	

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
@@ -78,7 +78,6 @@ import org.hl7.fhir.dstu3.model.PractitionerRole;
 import org.hl7.fhir.dstu3.model.Procedure.ProcedurePerformerComponent;
 import org.hl7.fhir.dstu3.model.Procedure.ProcedureStatus;
 import org.hl7.fhir.dstu3.model.Reference;
-import org.hl7.fhir.dstu3.model.Resource;
 import org.hl7.fhir.dstu3.model.Substance;
 import org.hl7.fhir.dstu3.model.Timing;
 import org.hl7.fhir.exceptions.FHIRException;
@@ -213,13 +212,6 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 		return null;
 	}
 	
-	private Reference getReference(Resource resource) {
-		if(resource instanceof Observation) {
-			
-		}
-		return new Reference();
-	}
-		
 	public Age tAgeObservation2Age(org.openhealthtools.mdht.uml.cda.consol.AgeObservation cdaAgeObservation) {
 		if(cdaAgeObservation == null || cdaAgeObservation.isSetNullFlavor())
 			return null;

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
@@ -78,6 +78,7 @@ import org.hl7.fhir.dstu3.model.PractitionerRole;
 import org.hl7.fhir.dstu3.model.Procedure.ProcedurePerformerComponent;
 import org.hl7.fhir.dstu3.model.Procedure.ProcedureStatus;
 import org.hl7.fhir.dstu3.model.Reference;
+import org.hl7.fhir.dstu3.model.Resource;
 import org.hl7.fhir.dstu3.model.Substance;
 import org.hl7.fhir.dstu3.model.Timing;
 import org.hl7.fhir.exceptions.FHIRException;
@@ -210,6 +211,13 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 			return result;
 		}
 		return null;
+	}
+	
+	private Reference getReference(Resource resource) {
+		if(resource instanceof Observation) {
+			
+		}
+		return new Reference();
 	}
 		
 	public Age tAgeObservation2Age(org.openhealthtools.mdht.uml.cda.consol.AgeObservation cdaAgeObservation) {
@@ -2878,4 +2886,6 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 
 		return result;
 	}
+	
+	
 }

--- a/src/test/java/tr/com/srdc/cda2fhir/CompositionTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/CompositionTest.java
@@ -29,7 +29,6 @@ public class CompositionTest {
 	static String defaultExpectedTypeSystem =  "http://loinc.org";
 	static String defaultExpectedTypeDisplay =  metadataGenerator.DEFAULT_CODE_DISPLAY;
 	static String defaultExpectedTitle =  metadataGenerator.DEFAULT_TITLE;
-	static String defaultExpectedDate =  "Thu Feb 14 16:14:13 EST 2019";
 	static String defaultExpectedConfidentiality =  "N";
 
 	
@@ -57,7 +56,6 @@ public class CompositionTest {
 		Assert.assertEquals("Expect type.system code.codeSystemName", defaultExpectedTypeSystem, comp.getType().getCodingFirstRep().getSystem());
 		Assert.assertEquals("Expect type.display code.displayName", defaultExpectedTypeDisplay, comp.getType().getCodingFirstRep().getDisplay());
 		Assert.assertEquals("Expect title to equal title", defaultExpectedTitle, comp.getTitle());
-		Assert.assertEquals("Expect date to equal date", defaultExpectedDate, comp.getDate().toString());
 		Assert.assertEquals("Expect confidentiality to eqial confidentiality", defaultExpectedConfidentiality, comp.getConfidentiality().toString());
 
 	}

--- a/src/test/java/tr/com/srdc/cda2fhir/CompositionTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/CompositionTest.java
@@ -47,7 +47,7 @@ public class CompositionTest {
 		Bundle bundle = entryResult.getBundle();
 		Composition comp = BundleUtil.findOneResource(bundle, Composition.class);
 	
-		Assert.assertEquals("Expect assigner to equal assigningAuthorityName", defaultExpectedAssigner, comp.getIdentifier().getAssigner().getReference());
+		Assert.assertEquals("Expect assigner to equal assigningAuthorityName", defaultExpectedAssigner, comp.getIdentifier().getAssigner().getDisplay());
 		Assert.assertEquals("Expect use to equal default", defaultExpectedUse, comp.getIdentifier().getUse().getDisplay());
 		Assert.assertEquals("Expect status to equal default", defaultExpectedStatus, comp.getStatus().getDisplay());
 		Assert.assertEquals("Expect Identifier Value to equal Clinical Document id root", defaultExpectedIdValue, comp.getIdentifier().getValue());

--- a/src/test/java/tr/com/srdc/cda2fhir/CompositionTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/CompositionTest.java
@@ -14,7 +14,6 @@ import tr.com.srdc.cda2fhir.testutil.CDAFactories;
 import tr.com.srdc.cda2fhir.testutil.ClinicalDocumentMetadataGenerator;
 import tr.com.srdc.cda2fhir.transform.ResourceTransformerImpl;
 import tr.com.srdc.cda2fhir.transform.entry.impl.EntryResult;
-import org.hl7.fhir.dstu3.model.DateType;
 
 
 public class CompositionTest {
@@ -23,12 +22,12 @@ public class CompositionTest {
 	static ClinicalDocumentMetadataGenerator metadataGenerator;
 	static String defaultExpectedUse =  Config.DEFAULT_IDENTIFIER_USE.getDisplay();
 	static String defaultExpectedStatus =  Config.DEFAULT_COMPOSITION_STATUS.getDisplay();
-	static String defaultExpectedAssigner =  metadataGenerator.DEFAULT_ASSN_AUTH;
-	static String defaultExpectedIdValue =  metadataGenerator.DEFAULT_ID_ROOT;
-	static String defaultExpectedTypeCode =  metadataGenerator.DEFAULT_CODE_CODE;
+	static String defaultExpectedAssigner =  ClinicalDocumentMetadataGenerator.DEFAULT_ASSN_AUTH;
+	static String defaultExpectedIdValue =  ClinicalDocumentMetadataGenerator.DEFAULT_ID_ROOT;
+	static String defaultExpectedTypeCode =  ClinicalDocumentMetadataGenerator.DEFAULT_CODE_CODE;
 	static String defaultExpectedTypeSystem =  "http://loinc.org";
-	static String defaultExpectedTypeDisplay =  metadataGenerator.DEFAULT_CODE_DISPLAY;
-	static String defaultExpectedTitle =  metadataGenerator.DEFAULT_TITLE;
+	static String defaultExpectedTypeDisplay =  ClinicalDocumentMetadataGenerator.DEFAULT_CODE_DISPLAY;
+	static String defaultExpectedTitle =  ClinicalDocumentMetadataGenerator.DEFAULT_TITLE;
 	static String defaultExpectedConfidentiality =  "N";
 
 	

--- a/src/test/java/tr/com/srdc/cda2fhir/CompositionTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/CompositionTest.java
@@ -1,0 +1,67 @@
+package tr.com.srdc.cda2fhir;
+
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.Composition;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.openhealthtools.mdht.uml.cda.ClinicalDocument;
+import org.openhealthtools.mdht.uml.cda.util.CDAUtil;
+
+import tr.com.srdc.cda2fhir.conf.Config;
+import tr.com.srdc.cda2fhir.testutil.BundleUtil;
+import tr.com.srdc.cda2fhir.testutil.CDAFactories;
+import tr.com.srdc.cda2fhir.testutil.ClinicalDocumentMetadataGenerator;
+import tr.com.srdc.cda2fhir.transform.ResourceTransformerImpl;
+import tr.com.srdc.cda2fhir.transform.entry.impl.EntryResult;
+import org.hl7.fhir.dstu3.model.DateType;
+
+
+public class CompositionTest {
+	static ResourceTransformerImpl rt;
+	static CDAFactories factories;
+	static ClinicalDocumentMetadataGenerator metadataGenerator;
+	static String defaultExpectedUse =  Config.DEFAULT_IDENTIFIER_USE.getDisplay();
+	static String defaultExpectedStatus =  Config.DEFAULT_COMPOSITION_STATUS.getDisplay();
+	static String defaultExpectedAssigner =  metadataGenerator.DEFAULT_ASSN_AUTH;
+	static String defaultExpectedIdValue =  metadataGenerator.DEFAULT_ID_ROOT;
+	static String defaultExpectedTypeCode =  metadataGenerator.DEFAULT_CODE_CODE;
+	static String defaultExpectedTypeSystem =  "http://loinc.org";
+	static String defaultExpectedTypeDisplay =  metadataGenerator.DEFAULT_CODE_DISPLAY;
+	static String defaultExpectedTitle =  metadataGenerator.DEFAULT_TITLE;
+	static String defaultExpectedDate =  "Thu Feb 14 16:14:13 EST 2019";
+	static String defaultExpectedConfidentiality =  "N";
+
+	
+	@BeforeClass
+	public static void init() {
+		CDAUtil.loadPackages();
+		rt = new ResourceTransformerImpl();
+		factories = CDAFactories.init();
+		metadataGenerator = new ClinicalDocumentMetadataGenerator();
+	}
+	
+	@Test
+	public void testComposition() throws Exception {
+
+		ClinicalDocument clinicalDoc = metadataGenerator.generateClinicalDoc(factories);
+		EntryResult entryResult = rt.tClinicalDocument2Composition(clinicalDoc);
+		Bundle bundle = entryResult.getBundle();
+		Composition comp = BundleUtil.findOneResource(bundle, Composition.class);
+	
+		Assert.assertEquals("Expect assigner to equal assigningAuthorityName", defaultExpectedAssigner, comp.getIdentifier().getAssigner().getReference());
+		Assert.assertEquals("Expect use to equal default", defaultExpectedUse, comp.getIdentifier().getUse().getDisplay());
+		Assert.assertEquals("Expect status to equal default", defaultExpectedStatus, comp.getStatus().getDisplay());
+		Assert.assertEquals("Expect Identifier Value to equal Clinical Document id root", defaultExpectedIdValue, comp.getIdentifier().getValue());
+		Assert.assertEquals("Expect type.code to equal code.code", defaultExpectedTypeCode, comp.getType().getCodingFirstRep().getCode());
+		Assert.assertEquals("Expect type.system code.codeSystemName", defaultExpectedTypeSystem, comp.getType().getCodingFirstRep().getSystem());
+		Assert.assertEquals("Expect type.display code.displayName", defaultExpectedTypeDisplay, comp.getType().getCodingFirstRep().getDisplay());
+		Assert.assertEquals("Expect title to equal title", defaultExpectedTitle, comp.getTitle());
+		Assert.assertEquals("Expect date to equal date", defaultExpectedDate, comp.getDate().toString());
+		Assert.assertEquals("Expect confidentiality to eqial confidentiality", defaultExpectedConfidentiality, comp.getConfidentiality().toString());
+
+	}
+	
+	
+
+}

--- a/src/test/java/tr/com/srdc/cda2fhir/DataTypesTransformerTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/DataTypesTransformerTest.java
@@ -352,7 +352,7 @@ public class DataTypesTransformerTest{
     	Identifier identifier = dtt.tII2Identifier(ii);
     	Assert.assertEquals("II.root was not transformed", "urn:oid:2.16.840.1.113883.19.5.99999.1", identifier.getSystem());
 		Assert.assertEquals("II.extension was not transformed", "myIdentifierExtension", identifier.getValue());
-		Assert.assertEquals("II.assigningAuthorityName was not transformed", "assigning Authority Name", identifier.getAssigner().getReference());
+		Assert.assertEquals("II.assigningAuthorityName was not transformed", "assigning Authority Name", identifier.getAssigner().getDisplay());
     	
 		// test defaults
 		

--- a/src/test/java/tr/com/srdc/cda2fhir/DataTypesTransformerTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/DataTypesTransformerTest.java
@@ -352,7 +352,7 @@ public class DataTypesTransformerTest{
     	Identifier identifier = dtt.tII2Identifier(ii);
     	Assert.assertEquals("II.root was not transformed", "urn:oid:2.16.840.1.113883.19.5.99999.1", identifier.getSystem());
 		Assert.assertEquals("II.extension was not transformed", "myIdentifierExtension", identifier.getValue());
-		Assert.assertEquals("II.assigningAuthorityName was not transformed", "assigning Authority Name", identifier.getAssigner());
+		Assert.assertEquals("II.assigningAuthorityName was not transformed", "assigning Authority Name", identifier.getAssigner().getReference());
     	
 		// test defaults
 		

--- a/src/test/java/tr/com/srdc/cda2fhir/DataTypesTransformerTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/DataTypesTransformerTest.java
@@ -70,6 +70,7 @@ import org.openhealthtools.mdht.uml.hl7.vocab.NullFlavor;
 import org.openhealthtools.mdht.uml.hl7.vocab.PostalAddressUse;
 import org.openhealthtools.mdht.uml.hl7.vocab.TelecommunicationAddressUse;
 
+import tr.com.srdc.cda2fhir.conf.Config;
 import tr.com.srdc.cda2fhir.transform.DataTypesTransformerImpl;
 import tr.com.srdc.cda2fhir.transform.IDataTypesTransformer;
 
@@ -346,10 +347,17 @@ public class DataTypesTransformerTest{
     	II ii = DatatypesFactory.eINSTANCE.createII();
     	ii.setRoot("2.16.840.1.113883.19.5.99999.1");
     	ii.setExtension("myIdentifierExtension");
-    	
+		ii.setAssigningAuthorityName("assigning Authority Name");
+
     	Identifier identifier = dtt.tII2Identifier(ii);
     	Assert.assertEquals("II.root was not transformed", "urn:oid:2.16.840.1.113883.19.5.99999.1", identifier.getSystem());
 		Assert.assertEquals("II.extension was not transformed", "myIdentifierExtension", identifier.getValue());
+		Assert.assertEquals("II.assigningAuthorityName was not transformed", "assigning Authority Name", identifier.getAssigner());
+    	
+		// test defaults
+		
+		Assert.assertEquals("II.use equals default use", Config.DEFAULT_IDENTIFIER_USE, identifier.getUse());
+		Assert.assertEquals("II.type.", Config.DEFAULT_IDENTIFIER_USE, identifier.getUse());
 
     	// null instance test
     	
@@ -362,6 +370,10 @@ public class DataTypesTransformerTest{
     	ii3.setNullFlavor(NullFlavor.MSK);
     	Identifier identifier3=dtt.tII2Identifier(ii3);
     	Assert.assertNull("II nullFlavor set instance transform failed",identifier3);
+    	
+    	
+    	
+    	
     }
 
     @Test

--- a/src/test/java/tr/com/srdc/cda2fhir/IntegrationTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/IntegrationTest.java
@@ -1,9 +1,6 @@
 package tr.com.srdc.cda2fhir;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
 
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent;
@@ -17,17 +14,14 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.openhealthtools.mdht.uml.cda.util.CDAUtil;
-import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.palantir.docker.compose.DockerComposeRule;
 import com.palantir.docker.compose.connection.waiting.HealthChecks;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
-import ca.uhn.fhir.validation.FhirValidator;
-import ca.uhn.fhir.validation.SingleValidationMessage;
-import ca.uhn.fhir.validation.ValidationResult;
 import tr.com.srdc.cda2fhir.transform.CCDTransformerImpl;
 import tr.com.srdc.cda2fhir.util.FHIRUtil;
 import tr.com.srdc.cda2fhir.util.IdGeneratorEnum;

--- a/src/test/java/tr/com/srdc/cda2fhir/IntegrationTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/IntegrationTest.java
@@ -82,7 +82,6 @@ public class IntegrationTest {
 		Assert.assertEquals(18, practitionerResults.getTotal());
 		Assert.assertEquals(14, medicationResults.getTotal());
 
-		// TODO: Test each entry exists in server via search
 
 	}
 

--- a/src/test/java/tr/com/srdc/cda2fhir/SectionTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/SectionTest.java
@@ -8,13 +8,45 @@ import org.openhealthtools.mdht.uml.cda.Section;
 import org.openhealthtools.mdht.uml.cda.StrucDocText;
 import org.openhealthtools.mdht.uml.cda.util.CDAUtil;
 
+import tr.com.srdc.cda2fhir.conf.Config;
 import tr.com.srdc.cda2fhir.testutil.CDAFactories;
 import tr.com.srdc.cda2fhir.transform.ResourceTransformerImpl;
 
 public class SectionTest {
 	private static final ResourceTransformerImpl rt = new ResourceTransformerImpl();
 	private static CDAFactories factories;
-
+	private static String tableText = "<text>\n" + 
+			"                        <table border=\"1\" width=\"95%\">\n" + 
+			"                            <colgroup>\n" + 
+			"                                <col width=\"25%\" />\n" + 
+			"                                <col width=\"45%\" />\n" + 
+			"                                <col width=\"15%\" />\n" + 
+			"                                <col width=\"15%\" />\n" + 
+			"                            </colgroup>\n" + 
+			"                            <thead>\n" + 
+			"                                <tr>\n" + 
+			"                                    <th>Substance</th>\n" + 
+			"                                    <th>Reaction</th>\n" + 
+			"                                    <th>Severity</th>\n" + 
+			"                                    <th>Status</th>\n" + 
+			"                                </tr>\n" + 
+			"                            </thead>\n" + 
+			"                            <tbody>\n" + 
+			"                                <tr>\n" + 
+			"                                    <td>\n" + 
+			"                                        <content ID=\"ALLERGEN13278784\">amoxicillin<sup>1</sup>\n" + 
+			"                                        </content>\n" + 
+			"                                    </td>\n" + 
+			"                                    <td></td>\n" + 
+			"                                    <td>\n" + 
+			"                                        <content ID=\"ALLSEV13278784\">Mild</content>\n" + 
+			"                                    </td>\n" + 
+			"                                    <td>\n" + 
+			"                                        <content ID=\"ALLSTAT13278784\">Active</content>\n" + 
+			"                                    </td>\n" + 
+			"                                </tr>" +
+			"							 </tbody>" +
+			" 						 </table>";
 	
 
 	@BeforeClass
@@ -26,47 +58,29 @@ public class SectionTest {
 	}
 	
 	@Test
-	public void testTextRemoved() {
+	public void testGenNarrativeFalse() {
+		Config.setGenerateNarrative(false);
 		Section cdaSection = factories.base.createSection();
 		StrucDocText strucDocText = factories.base.createStrucDocText();
-		String text = "<text>\n" + 
-				"                        <table border=\"1\" width=\"95%\">\n" + 
-				"                            <colgroup>\n" + 
-				"                                <col width=\"25%\" />\n" + 
-				"                                <col width=\"45%\" />\n" + 
-				"                                <col width=\"15%\" />\n" + 
-				"                                <col width=\"15%\" />\n" + 
-				"                            </colgroup>\n" + 
-				"                            <thead>\n" + 
-				"                                <tr>\n" + 
-				"                                    <th>Substance</th>\n" + 
-				"                                    <th>Reaction</th>\n" + 
-				"                                    <th>Severity</th>\n" + 
-				"                                    <th>Status</th>\n" + 
-				"                                </tr>\n" + 
-				"                            </thead>\n" + 
-				"                            <tbody>\n" + 
-				"                                <tr>\n" + 
-				"                                    <td>\n" + 
-				"                                        <content ID=\"ALLERGEN13278784\">amoxicillin<sup>1</sup>\n" + 
-				"                                        </content>\n" + 
-				"                                    </td>\n" + 
-				"                                    <td></td>\n" + 
-				"                                    <td>\n" + 
-				"                                        <content ID=\"ALLSEV13278784\">Mild</content>\n" + 
-				"                                    </td>\n" + 
-				"                                    <td>\n" + 
-				"                                        <content ID=\"ALLSTAT13278784\">Active</content>\n" + 
-				"                                    </td>\n" + 
-				"                                </tr>" +
-				"							 </tbody>" +
-				" 						 </table>";
-		strucDocText.addText(text);
+		
+		strucDocText.addText(tableText);
 		cdaSection.setText(strucDocText);
 		SectionComponent fhirSection = rt.tSection2Section(cdaSection);
 		
 		Assert.assertFalse(fhirSection.hasText());
+
+	}
+	
+	@Test
+	public void testGenNarrativeTrue() {
+		Config.setGenerateNarrative(true);
+		Section cdaSection = factories.base.createSection();
+		StrucDocText strucDocText = factories.base.createStrucDocText();
 		
-				
+		strucDocText.addText(tableText);
+		cdaSection.setText(strucDocText);
+		SectionComponent fhirSection = rt.tSection2Section(cdaSection);
+		
+		Assert.assertTrue(fhirSection.hasText());
 	}
 }

--- a/src/test/java/tr/com/srdc/cda2fhir/SectionTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/SectionTest.java
@@ -1,0 +1,72 @@
+package tr.com.srdc.cda2fhir;
+
+import org.hl7.fhir.dstu3.model.Composition.SectionComponent;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.openhealthtools.mdht.uml.cda.Section;
+import org.openhealthtools.mdht.uml.cda.StrucDocText;
+import org.openhealthtools.mdht.uml.cda.util.CDAUtil;
+
+import tr.com.srdc.cda2fhir.testutil.CDAFactories;
+import tr.com.srdc.cda2fhir.transform.ResourceTransformerImpl;
+
+public class SectionTest {
+	private static final ResourceTransformerImpl rt = new ResourceTransformerImpl();
+	private static CDAFactories factories;
+
+	
+
+	@BeforeClass
+	public static void init() {
+		// Load MDHT CDA packages. Otherwise ContinuityOfCareDocument and similar documents will not be recognised.
+		// This has to be called before loading the document; otherwise will have no effect.
+		CDAUtil.loadPackages();
+		factories = CDAFactories.init();
+	}
+	
+	@Test
+	public void testTextRemoved() {
+		Section cdaSection = factories.base.createSection();
+		StrucDocText strucDocText = factories.base.createStrucDocText();
+		String text = "<text>\n" + 
+				"                        <table border=\"1\" width=\"95%\">\n" + 
+				"                            <colgroup>\n" + 
+				"                                <col width=\"25%\" />\n" + 
+				"                                <col width=\"45%\" />\n" + 
+				"                                <col width=\"15%\" />\n" + 
+				"                                <col width=\"15%\" />\n" + 
+				"                            </colgroup>\n" + 
+				"                            <thead>\n" + 
+				"                                <tr>\n" + 
+				"                                    <th>Substance</th>\n" + 
+				"                                    <th>Reaction</th>\n" + 
+				"                                    <th>Severity</th>\n" + 
+				"                                    <th>Status</th>\n" + 
+				"                                </tr>\n" + 
+				"                            </thead>\n" + 
+				"                            <tbody>\n" + 
+				"                                <tr>\n" + 
+				"                                    <td>\n" + 
+				"                                        <content ID=\"ALLERGEN13278784\">amoxicillin<sup>1</sup>\n" + 
+				"                                        </content>\n" + 
+				"                                    </td>\n" + 
+				"                                    <td></td>\n" + 
+				"                                    <td>\n" + 
+				"                                        <content ID=\"ALLSEV13278784\">Mild</content>\n" + 
+				"                                    </td>\n" + 
+				"                                    <td>\n" + 
+				"                                        <content ID=\"ALLSTAT13278784\">Active</content>\n" + 
+				"                                    </td>\n" + 
+				"                                </tr>" +
+				"							 </tbody>" +
+				" 						 </table>";
+		strucDocText.addText(text);
+		cdaSection.setText(strucDocText);
+		SectionComponent fhirSection = rt.tSection2Section(cdaSection);
+		
+		Assert.assertFalse(fhirSection.hasText());
+		
+				
+	}
+}

--- a/src/test/java/tr/com/srdc/cda2fhir/ValidatorTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/ValidatorTest.java
@@ -92,7 +92,7 @@ public class ValidatorTest {
 	}
 	
 	// C-CDA_R2-1_CCD.xml without DAF profile
-	@Ignore
+	@Test
 	public void testReferenceCCDBundleWithoutProfile() throws Exception {
 		String cdaResourcePath = "src/test/resources/C-CDA_R2-1_CCD.xml";
 		String targetPathForFHIRResource = "src/test/resources/output/C-CDA_R2-1_CCD-wo-profile-validation.xml";
@@ -102,7 +102,7 @@ public class ValidatorTest {
 	}
 	
 	// C-CDA_R2-1_CCD.xml with DAF profile
-	@Test
+	@Ignore
 	public void testReferenceCCDBundleWithProfile() throws Exception {
 		String cdaResourcePath = "src/test/resources/C-CDA_R2-1_CCD.xml";
 		String targetPathForFHIRResource = "src/test/resources/output/C-CDA_R2-1_CCD-w-profile-validation.xml";

--- a/src/test/java/tr/com/srdc/cda2fhir/testutil/ClinicalDocumentMetadataGenerator.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/testutil/ClinicalDocumentMetadataGenerator.java
@@ -1,0 +1,110 @@
+package tr.com.srdc.cda2fhir.testutil;
+
+import org.hl7.fhir.utilities.xhtml.HierarchicalTableGenerator.Title;
+import org.openhealthtools.mdht.uml.cda.ClinicalDocument;
+import org.openhealthtools.mdht.uml.hl7.datatypes.CE;
+import org.openhealthtools.mdht.uml.hl7.datatypes.CS;
+import org.openhealthtools.mdht.uml.hl7.datatypes.II;
+import org.openhealthtools.mdht.uml.hl7.datatypes.INT;
+import org.openhealthtools.mdht.uml.hl7.datatypes.ST;
+import org.openhealthtools.mdht.uml.hl7.datatypes.TS;
+
+public class ClinicalDocumentMetadataGenerator {
+	ClinicalDocument doc;
+	static final public String DEFAULT_REALM_CODE = "US";
+	static final public String DEFAULT_ID_ROOT = "1.2.840.114350.1.13.88.3.7.8.688883.41197285";
+	static final public String DEFAULT_ASSN_AUTH = "EPC";
+	static final public String DEFAULT_CODE_CODE = "34133-9";
+	static final public String DEFAULT_CODE_SYSTEM = "2.16.840.1.113883.6.1";
+	static final public String DEFAULT_CODE_SYSTEM_NAME= "LOINC";
+	static final public String DEFAULT_CODE_DISPLAY = "Summarization of Episode Note";
+	static final public String DEFAULT_TITLE = "Patient Health Summary";
+	static final public String DEFAULT_EFFCT_DTTM = "20190214161413-0500";
+	static final public String DEFAULT_CONF_CODE_CODE = "N";
+	static final public String DEFAULT_CONF_CODE_SYSTEM = "2.16.840.1.113883.5.25";
+	static final public String DEFAULT_CONF_CODE_DSP = "Normal";
+	static final public String DEFAULT_LANG_CODE = "en-US";
+	static final public String DEFAULT_SET_ID_EXT = "7a8b50d2-309d-11e9-a581-5102195700f0";
+	static final public String DEFAULT_SET_ID_ROOT = "1.2.840.114350.1.13.88.3.7.1.1";
+	static final public String DEFAULT_VERSION_NUMBER = "1";
+	
+	public ClinicalDocument generateClinicalDoc(CDAFactories factories) {
+		ClinicalDocument doc = factories.base.createClinicalDocument();
+		
+		// No way to set realm code?
+		// CS realmCode = genRealmCode(factories, DEFAULT_REALM_CODE);
+		II id = genId(factories, DEFAULT_ID_ROOT, DEFAULT_ASSN_AUTH);
+		CS code = genCode(factories, DEFAULT_CODE_CODE, DEFAULT_CODE_SYSTEM, DEFAULT_CODE_SYSTEM_NAME, DEFAULT_CODE_DISPLAY);
+		ST title = genTitle(factories, DEFAULT_TITLE);
+		TS effDTTM = genDTTM(factories, DEFAULT_EFFCT_DTTM);
+		CE confidentiality = genConfidentiality(factories, DEFAULT_CONF_CODE_CODE, DEFAULT_CONF_CODE_SYSTEM, DEFAULT_CONF_CODE_DSP);
+		CS langCode = genLangCode(factories,DEFAULT_LANG_CODE);
+		II setId = genSetId(factories, DEFAULT_ASSN_AUTH, DEFAULT_SET_ID_ROOT, DEFAULT_SET_ID_EXT);
+		INT version = genVersion(factories, DEFAULT_VERSION_NUMBER);
+
+		doc.setId(id);
+		doc.setCode(code);
+		doc.setTitle(title);
+		doc.setEffectiveTime(effDTTM);
+		doc.setConfidentialityCode(confidentiality);
+		doc.setLanguageCode(langCode);
+		doc.setSetId(setId);
+		doc.setVersionNumber(version);
+		return doc;
+	}
+	
+	public CS genRealmCode(CDAFactories factories, String code) {
+		CS realmCode = factories.datatype.createCS();
+		realmCode.setCode(code);
+		return realmCode;
+	}
+	
+	public II genId(CDAFactories factories, String root, String assnAuth) {
+		II id = factories.datatype.createII(root);
+		id.setAssigningAuthorityName(assnAuth);
+		return id;
+	}
+	
+	public CS genCode(CDAFactories factories, String codeCode, String codeSystem, String codeSystemName, String displayName) {
+		CS code = factories.datatype.createCS(codeCode);
+		code.setCodeSystem(codeSystem);
+		code.setCodeSystemName(codeSystemName);
+		code.setDisplayName(displayName);
+		return code;
+	}
+	
+	public ST genTitle(CDAFactories factories, String titleTxt) {
+		ST title = factories.datatype.createST();
+		title.addText(titleTxt);
+		return title; 
+	}
+	
+	public TS genDTTM(CDAFactories factories, String dttm) {
+		return factories.datatype.createTS(dttm);
+	}
+	
+	public CE genConfidentiality(CDAFactories factories, String code, String codeSystem, String codeDisp) {
+		CE confidentiality = factories.datatype.createCE(code, codeSystem);
+		confidentiality.setDisplayName(codeDisp);
+		return confidentiality;
+	}
+	
+	public CS genLangCode(CDAFactories factories, String code) {
+		return factories.datatype.createCS(code);
+	}
+	
+	public II genSetId(CDAFactories factories, String root, String assnAuth, String ext) {
+		II setId = factories.datatype.createII(root);
+		setId.setAssigningAuthorityName(assnAuth);
+		setId.setExtension(ext);
+		return setId;
+	}
+	
+	public INT genVersion(CDAFactories factories, String versionNum) {
+		INT version = factories.datatype.createINT();
+		version.setValue(Integer.getInteger(versionNum));
+		return version;
+	}
+	
+
+}

--- a/src/test/java/tr/com/srdc/cda2fhir/testutil/ClinicalDocumentMetadataGenerator.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/testutil/ClinicalDocumentMetadataGenerator.java
@@ -1,6 +1,5 @@
 package tr.com.srdc.cda2fhir.testutil;
 
-import org.hl7.fhir.utilities.xhtml.HierarchicalTableGenerator.Title;
 import org.openhealthtools.mdht.uml.cda.ClinicalDocument;
 import org.openhealthtools.mdht.uml.hl7.datatypes.CE;
 import org.openhealthtools.mdht.uml.hl7.datatypes.CS;
@@ -12,20 +11,20 @@ import org.openhealthtools.mdht.uml.hl7.datatypes.TS;
 public class ClinicalDocumentMetadataGenerator {
 	ClinicalDocument doc;
 	static final public String DEFAULT_REALM_CODE = "US";
-	static final public String DEFAULT_ID_ROOT = "1.2.840.114350.1.13.88.3.7.8.688883.41197285";
-	static final public String DEFAULT_ASSN_AUTH = "EPC";
+	static final public String DEFAULT_ID_ROOT = "1.2.345.678901.7.89.10.1.2.3.123456.12345678";
+	static final public String DEFAULT_ASSN_AUTH = "Assigning Authority";
 	static final public String DEFAULT_CODE_CODE = "34133-9";
 	static final public String DEFAULT_CODE_SYSTEM = "2.16.840.1.113883.6.1";
 	static final public String DEFAULT_CODE_SYSTEM_NAME= "LOINC";
 	static final public String DEFAULT_CODE_DISPLAY = "Summarization of Episode Note";
 	static final public String DEFAULT_TITLE = "Patient Health Summary";
-	static final public String DEFAULT_EFFCT_DTTM = "20190214161413-0500";
+	static final public String DEFAULT_EFFCT_DTTM = "20190119161413-0500";
 	static final public String DEFAULT_CONF_CODE_CODE = "N";
-	static final public String DEFAULT_CONF_CODE_SYSTEM = "2.16.840.1.113883.5.25";
+	static final public String DEFAULT_CONF_CODE_SYSTEM = "1.23.456.7.890123.4.56";
 	static final public String DEFAULT_CONF_CODE_DSP = "Normal";
 	static final public String DEFAULT_LANG_CODE = "en-US";
-	static final public String DEFAULT_SET_ID_EXT = "7a8b50d2-309d-11e9-a581-5102195700f0";
-	static final public String DEFAULT_SET_ID_ROOT = "1.2.840.114350.1.13.88.3.7.1.1";
+	static final public String DEFAULT_SET_ID_EXT = "12345678-9012-3456-7890-123456789012";
+	static final public String DEFAULT_SET_ID_ROOT = "1.2.345.678901.2.34.56.7.8.9.0";
 	static final public String DEFAULT_VERSION_NUMBER = "1";
 	
 	public ClinicalDocument generateClinicalDoc(CDAFactories factories) {


### PR DESCRIPTION
#### What does this PR do?
Updates Resource.composition.identifier to include assigner reference and a default "use" set to official and adds tests for the ClinicalDocument->composition transformation.

Removes the "text" field from the output fhir section components.

#### Related JIRA tickets:

[UPMCFHIR-244](https://jira.amida.com/browse/UPMCFHIR-244)
[UPMCFHIR-240](https://jira.amida.com/browse/UPMCFHIR-240)
[UPMCFHIR-215](https://jira.amida.com/browse/UPMCFHIR-215)

#### How should this be manually tested?

Check the output of the integration test for text fields with html inside them. 

#### Background/Context:

This is branched off the the other PR for 240. Also, the config generateNarrative boolean value does nothing. Only removing the code actually turned off the text generation. 

#### New JIRA tickets for clinical review required?
