### PR TITLE
Upmcfhir 270 text support

### DIFF
--- a/src/main/java/tr/com/srdc/cda2fhir/transform/DataTypesTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/DataTypesTransformerImpl.java
@@ -242,12 +242,26 @@ public class DataTypesTransformerImpl implements IDataTypesTransformer, Serializ
 
 	@Override
 	public String tED2Annotation(ED ed, Map<String, String> idedAnnotations) {
-		if (ed != null && idedAnnotations != null) {
-			TEL tel = ed.getReference();
-			String value = tel.getValue();
-			if (value != null && value.charAt(0) == '#') {
-				String key = value.substring(1);
-				return idedAnnotations.get(key);
+
+		if (ed != null) {
+
+			// Getting Text Values.
+			String originalText = ed.getText();
+			if (!originalText.equals("")) {
+				return originalText;
+			}
+
+			if (idedAnnotations != null) {
+				// If no text try reference
+				TEL tel = ed.getReference();
+				if (!tel.equals(null)) {
+					String value = tel.getValue();
+					if (value != null && value.charAt(0) == '#') {
+						String key = value.substring(1);
+						return idedAnnotations.get(key);
+					}
+
+				}
 			}
 		}
 		return null;

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/DataTypesTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/DataTypesTransformerImpl.java
@@ -351,10 +351,6 @@ public class DataTypesTransformerImpl implements IDataTypesTransformer, Serializ
 			}
 		}
 
-		if (idedAnnotations != null) {
-			System.out.println(idedAnnotations);
-		}
-
 		String annotation = tED2Annotation(cd.getOriginalText(), idedAnnotations);
 		if (annotation != null) {
 			if (myCodeableConcept == null) {

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/DataTypesTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/DataTypesTransformerImpl.java
@@ -351,6 +351,10 @@ public class DataTypesTransformerImpl implements IDataTypesTransformer, Serializ
 			}
 		}
 
+		if (idedAnnotations != null) {
+			System.out.println(idedAnnotations);
+		}
+
 		String annotation = tED2Annotation(cd.getOriginalText(), idedAnnotations);
 		if (annotation != null) {
 			if (myCodeableConcept == null) {

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/DataTypesTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/DataTypesTransformerImpl.java
@@ -259,7 +259,7 @@ public class DataTypesTransformerImpl implements IDataTypesTransformer, Serializ
 			}
 
 			// If not fall back on text value.
-			String originalText = ed.getText();
+			String originalText = ed.getText().trim();
 			if (!originalText.equals("")) {
 				return originalText;
 			}

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/DataTypesTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/DataTypesTransformerImpl.java
@@ -245,14 +245,8 @@ public class DataTypesTransformerImpl implements IDataTypesTransformer, Serializ
 
 		if (ed != null) {
 
-			// Getting Text Values.
-			String originalText = ed.getText();
-			if (!originalText.equals("")) {
-				return originalText;
-			}
-
 			if (idedAnnotations != null) {
-				// If no text try reference
+				// Try to pull the reference.
 				TEL tel = ed.getReference();
 				if (!tel.equals(null)) {
 					String value = tel.getValue();
@@ -263,6 +257,13 @@ public class DataTypesTransformerImpl implements IDataTypesTransformer, Serializ
 
 				}
 			}
+
+			// If not fall back on text value.
+			String originalText = ed.getText();
+			if (!originalText.equals("")) {
+				return originalText;
+			}
+
 		}
 		return null;
 	}

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
@@ -1508,8 +1508,7 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 					// consumable.manufacturedProduct.manufacturedMaterial.code -> vaccineCode
 					if (manufacturedProduct.getManufacturedMaterial().getCode() != null
 							&& !manufacturedProduct.getManufacturedMaterial().getCode().isSetNullFlavor()) {
-						fhirImmunization.setVaccineCode(dtt.tCD2CodeableConcept(manufacturedMaterial.getCode(),
-								bundleInfo.getIdedAnnotations()));
+						fhirImmunization.setVaccineCode(dtt.tCD2CodeableConcept(manufacturedMaterial.getCode()));
 					}
 
 					// consumable.manufacturedProduct.manufacturedMaterial.lotNumberText ->

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
@@ -1508,7 +1508,8 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 					// consumable.manufacturedProduct.manufacturedMaterial.code -> vaccineCode
 					if (manufacturedProduct.getManufacturedMaterial().getCode() != null
 							&& !manufacturedProduct.getManufacturedMaterial().getCode().isSetNullFlavor()) {
-						fhirImmunization.setVaccineCode(dtt.tCD2CodeableConcept(manufacturedMaterial.getCode()));
+						fhirImmunization.setVaccineCode(dtt.tCD2CodeableConcept(manufacturedMaterial.getCode(),
+								bundleInfo.getIdedAnnotations()));
 					}
 
 					// consumable.manufacturedProduct.manufacturedMaterial.lotNumberText ->

--- a/src/main/java/tr/com/srdc/cda2fhir/util/EMFUtil.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/util/EMFUtil.java
@@ -29,18 +29,20 @@ public class EMFUtil {
 		}
 		for (Entry entry : featureMap) {
 			EStructuralFeature feature = entry.getEStructuralFeature();
-
 			if (feature instanceof EReference) {
 				AnyType anyType = (AnyType) entry.getValue();
-				String id = findAttribute(anyType.getAnyAttribute(), "id");
-				if (id != null) {
-					FeatureMap idValueMap = anyType.getMixed();
-					if (idValueMap != null && !idValueMap.isEmpty()) {
-						Object value = idValueMap.get(0).getValue();
-						if (value != null) {
-							result.put(id, value.toString());
+				if ("content".equalsIgnoreCase(feature.getName())) {
+					String id = findAttribute(anyType.getAnyAttribute(), "id");
+					if (id != null) {
+						FeatureMap idValueMap = anyType.getMixed();
+						if (idValueMap != null && !idValueMap.isEmpty()) {
+							Object value = idValueMap.get(0).getValue();
+							if (value != null) {
+								result.put(id, value.toString());
+							}
 						}
 					}
+					continue;
 				}
 				putReferences(anyType.getMixed(), result);
 			}

--- a/src/main/java/tr/com/srdc/cda2fhir/util/EMFUtil.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/util/EMFUtil.java
@@ -53,6 +53,12 @@ public class EMFUtil {
 		}
 	}
 
+	/***
+	 * Pulls text references out of source HTML for later use.
+	 * 
+	 * @param text the structured text portion of the CCD document.
+	 * @return map of ids and values from that section.
+	 */
 	static public Map<String, String> findReferences(StrucDocText text) {
 		Map<String, String> result = new HashMap<String, String>();
 		FeatureMap featureMap = text.getMixed();

--- a/src/main/java/tr/com/srdc/cda2fhir/util/EMFUtil.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/util/EMFUtil.java
@@ -1,5 +1,6 @@
 package tr.com.srdc.cda2fhir.util;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -11,6 +12,9 @@ import org.eclipse.emf.ecore.xml.type.AnyType;
 import org.openhealthtools.mdht.uml.cda.StrucDocText;
 
 public class EMFUtil {
+
+	private static String[] supportedTypes = { "content", "td", "paragraph" };
+
 	static private String findAttribute(FeatureMap attributes, String name) {
 		if (attributes != null) {
 			for (Entry attribute : attributes) {
@@ -31,7 +35,8 @@ public class EMFUtil {
 			EStructuralFeature feature = entry.getEStructuralFeature();
 			if (feature instanceof EReference) {
 				AnyType anyType = (AnyType) entry.getValue();
-				if ("content".equalsIgnoreCase(feature.getName())) {
+
+				if (Arrays.stream(supportedTypes).anyMatch(feature.getName().toLowerCase()::equals)) {
 					String id = findAttribute(anyType.getAnyAttribute(), "id");
 					if (id != null) {
 						FeatureMap idValueMap = anyType.getMixed();
@@ -42,7 +47,6 @@ public class EMFUtil {
 							}
 						}
 					}
-					continue;
 				}
 				putReferences(anyType.getMixed(), result);
 			}

--- a/src/main/java/tr/com/srdc/cda2fhir/util/EMFUtil.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/util/EMFUtil.java
@@ -29,20 +29,18 @@ public class EMFUtil {
 		}
 		for (Entry entry : featureMap) {
 			EStructuralFeature feature = entry.getEStructuralFeature();
+
 			if (feature instanceof EReference) {
 				AnyType anyType = (AnyType) entry.getValue();
-				if ("content".equalsIgnoreCase(feature.getName())) {
-					String id = findAttribute(anyType.getAnyAttribute(), "id");
-					if (id != null) {
-						FeatureMap idValueMap = anyType.getMixed();
-						if (idValueMap != null && !idValueMap.isEmpty()) {
-							Object value = idValueMap.get(0).getValue();
-							if (value != null) {
-								result.put(id, value.toString());
-							}
+				String id = findAttribute(anyType.getAnyAttribute(), "id");
+				if (id != null) {
+					FeatureMap idValueMap = anyType.getMixed();
+					if (idValueMap != null && !idValueMap.isEmpty()) {
+						Object value = idValueMap.get(0).getValue();
+						if (value != null) {
+							result.put(id, value.toString());
 						}
 					}
-					continue;
 				}
 				putReferences(anyType.getMixed(), result);
 			}

--- a/src/test/java/tr/com/srdc/cda2fhir/DataTypesTransformerTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/DataTypesTransformerTest.java
@@ -218,6 +218,18 @@ public class DataTypesTransformerTest {
 		cd3.setNullFlavor(NullFlavor.NI);
 		CodeableConcept codeableConcept3 = dtt.tCD2CodeableConcept(cd3);
 		Assert.assertNull("CodeableConcept.nullFlavor set instance transform failed", codeableConcept3);
+
+		// originalText test
+		CD cd4 = DatatypesFactory.eINSTANCE.createCD();
+		ED ed1 = DatatypesFactory.eINSTANCE.createED();
+		ed1.addText("help me rhonda");
+
+		cd4.setCode("code");
+		cd4.setCodeSystem("codeSystem");
+		cd4.setOriginalText(ed1);
+		CodeableConcept codeableConcept4 = dtt.tCD2CodeableConcept(cd4);
+		Assert.assertNull("CodeableConcept.nullFlavor set instance transform failed", codeableConcept4);
+
 	}
 
 	@Test

--- a/src/test/java/tr/com/srdc/cda2fhir/DataTypesTransformerTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/DataTypesTransformerTest.java
@@ -218,18 +218,6 @@ public class DataTypesTransformerTest {
 		cd3.setNullFlavor(NullFlavor.NI);
 		CodeableConcept codeableConcept3 = dtt.tCD2CodeableConcept(cd3);
 		Assert.assertNull("CodeableConcept.nullFlavor set instance transform failed", codeableConcept3);
-
-		// originalText test
-		CD cd4 = DatatypesFactory.eINSTANCE.createCD();
-		ED ed1 = DatatypesFactory.eINSTANCE.createED();
-		ed1.addText("help me rhonda");
-
-		cd4.setCode("code");
-		cd4.setCodeSystem("codeSystem");
-		cd4.setOriginalText(ed1);
-		CodeableConcept codeableConcept4 = dtt.tCD2CodeableConcept(cd4);
-		Assert.assertNull("CodeableConcept.nullFlavor set instance transform failed", codeableConcept4);
-
 	}
 
 	@Test

--- a/src/test/java/tr/com/srdc/cda2fhir/DataTypesTransformerTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/DataTypesTransformerTest.java
@@ -21,6 +21,7 @@ package tr.com.srdc.cda2fhir;
  */
 
 import java.math.BigDecimal;
+import java.util.Map;
 import java.util.TimeZone;
 
 import org.hl7.fhir.dstu3.model.Address;
@@ -69,6 +70,8 @@ import org.openhealthtools.mdht.uml.hl7.vocab.EntityNameUse;
 import org.openhealthtools.mdht.uml.hl7.vocab.NullFlavor;
 import org.openhealthtools.mdht.uml.hl7.vocab.PostalAddressUse;
 import org.openhealthtools.mdht.uml.hl7.vocab.TelecommunicationAddressUse;
+
+import com.helger.commons.collection.attr.StringMap;
 
 import tr.com.srdc.cda2fhir.conf.Config;
 import tr.com.srdc.cda2fhir.transform.DataTypesTransformerImpl;
@@ -219,16 +222,35 @@ public class DataTypesTransformerTest {
 		CodeableConcept codeableConcept3 = dtt.tCD2CodeableConcept(cd3);
 		Assert.assertNull("CodeableConcept.nullFlavor set instance transform failed", codeableConcept3);
 
-		// originalText test
+		// originalText test with reference.
 		CD cd4 = DatatypesFactory.eINSTANCE.createCD();
-		ED ed1 = DatatypesFactory.eINSTANCE.createED();
-		ed1.addText("help me rhonda");
+		ED ed4 = DatatypesFactory.eINSTANCE.createED();
+		TEL tel4 = DatatypesFactory.eINSTANCE.createTEL();
+		tel4.setValue("#fakeid1");
+		ed4.setReference(tel4);
 
 		cd4.setCode("code");
 		cd4.setCodeSystem("codeSystem");
-		cd4.setOriginalText(ed1);
-		CodeableConcept codeableConcept4 = dtt.tCD2CodeableConcept(cd4);
-		Assert.assertNull("CodeableConcept.nullFlavor set instance transform failed", codeableConcept4);
+		cd4.setOriginalText(ed4);
+
+		Map<String, String> idedAnnotations = new StringMap();
+		idedAnnotations.put("fakeid1", "fakevalue2");
+
+		CodeableConcept codeableConcept4 = dtt.tCD2CodeableConcept(cd4, idedAnnotations);
+		Assert.assertEquals("CodeableConcept sets text based on pointer and annotations", "fakevalue2",
+				codeableConcept4.getText());
+
+		// originalText test without reference.
+		CD cd5 = DatatypesFactory.eINSTANCE.createCD();
+		ED ed5 = DatatypesFactory.eINSTANCE.createED();
+		ed5.addText("originalText");
+		cd5.setCode("code");
+		cd5.setCodeSystem("codeSystem");
+		cd5.setOriginalText(ed5);
+
+		CodeableConcept codeableConcept5 = dtt.tCD2CodeableConcept(cd5);
+		Assert.assertEquals("CodeableConcept sets original text without references", "originalText",
+				codeableConcept5.getText());
 
 	}
 

--- a/src/test/java/tr/com/srdc/cda2fhir/DataTypesTransformerTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/DataTypesTransformerTest.java
@@ -252,6 +252,17 @@ public class DataTypesTransformerTest {
 		Assert.assertEquals("CodeableConcept sets original text without references", "originalText",
 				codeableConcept5.getText());
 
+		// empty padded strings don't create ref.
+		CD cd6 = DatatypesFactory.eINSTANCE.createCD();
+		ED ed6 = DatatypesFactory.eINSTANCE.createED();
+		ed6.addText("   ");
+		cd6.setCode("code");
+		cd6.setCodeSystem("codeSystem");
+		cd6.setOriginalText(ed6);
+
+		CodeableConcept codeableConcept6 = dtt.tCD2CodeableConcept(cd6);
+		Assert.assertEquals("CodeableConcept sets original text without references", null, codeableConcept6.getText());
+
 	}
 
 	@Test

--- a/src/test/java/tr/com/srdc/cda2fhir/ImmunizationActivityTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/ImmunizationActivityTest.java
@@ -12,6 +12,9 @@ import org.hl7.fhir.dstu3.model.Practitioner;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.openhealthtools.mdht.uml.cda.Consumable;
+import org.openhealthtools.mdht.uml.cda.ManufacturedProduct;
+import org.openhealthtools.mdht.uml.cda.Material;
 import org.openhealthtools.mdht.uml.cda.Performer2;
 import org.openhealthtools.mdht.uml.cda.consol.ImmunizationActivity;
 import org.openhealthtools.mdht.uml.cda.consol.ImmunizationRefusalReason;
@@ -19,6 +22,7 @@ import org.openhealthtools.mdht.uml.cda.consol.impl.ImmunizationActivityImpl;
 import org.openhealthtools.mdht.uml.cda.consol.impl.ImmunizationRefusalReasonImpl;
 import org.openhealthtools.mdht.uml.cda.util.CDAUtil;
 import org.openhealthtools.mdht.uml.hl7.datatypes.CD;
+import org.openhealthtools.mdht.uml.hl7.datatypes.CE;
 import org.openhealthtools.mdht.uml.hl7.datatypes.CS;
 import org.openhealthtools.mdht.uml.hl7.datatypes.ED;
 import org.openhealthtools.mdht.uml.hl7.datatypes.IVL_PQ;
@@ -169,7 +173,7 @@ public class ImmunizationActivityTest {
 		ImmunizationActivityImpl act = (ImmunizationActivityImpl) factories.consol.createImmunizationActivity();
 		verifyImmunizationStatus(act, null);
 
-		CD code = factories.datatype.createCD();
+		CE code = factories.datatype.createCE();
 		ED ed = factories.datatype.createED();
 		TEL tel = factories.datatype.createTEL();
 
@@ -179,6 +183,14 @@ public class ImmunizationActivityTest {
 		code.setCode("code");
 		code.setCodeSystem("codeSystem");
 		code.setOriginalText(ed);
+
+		Consumable cons = factories.base.createConsumable();
+		ManufacturedProduct manProd = factories.base.createManufacturedProduct();
+		Material mat = factories.base.createMaterial();
+		mat.setCode(code);
+		manProd.setManufacturedMaterial(mat);
+		cons.setManufacturedProduct(manProd);
+		act.setConsumable(cons);
 
 		Map<String, String> idedAnnotations = new StringMap();
 		idedAnnotations.put("fakeid1", "fakevalue2");

--- a/src/test/java/tr/com/srdc/cda2fhir/ImmunizationActivityTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/ImmunizationActivityTest.java
@@ -167,7 +167,6 @@ public class ImmunizationActivityTest {
 	@Test
 	public void testCodeReference() throws Exception {
 		ImmunizationActivityImpl act = (ImmunizationActivityImpl) factories.consol.createImmunizationActivity();
-		DiagnosticChain dxChain = new BasicDiagnostic();
 		verifyImmunizationStatus(act, null);
 
 		CD code = factories.datatype.createCD();

--- a/src/test/java/tr/com/srdc/cda2fhir/ValidatorTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/ValidatorTest.java
@@ -99,7 +99,7 @@ public class ValidatorTest {
 	}
 
 	// C-CDA_R2-1_CCD.xml without DAF profile
-	@Test
+	@Ignore
 	public void testReferenceCCDBundleWithoutProfile() throws Exception {
 		String cdaResourcePath = "src/test/resources/C-CDA_R2-1_CCD.xml";
 		String targetPathForFHIRResource = "src/test/resources/output/C-CDA_R2-1_CCD-wo-profile-validation.xml";
@@ -110,7 +110,7 @@ public class ValidatorTest {
 	}
 
 	// C-CDA_R2-1_CCD.xml with provenance
-	@Test
+	@Ignore
 	public void testReferenceCCDBundleWithProvenance() throws Exception {
 		String cdaResourcePath = "src/test/resources/C-CDA_R2-1_CCD.xml";
 		String targetPathForFHIRResource = "src/test/resources/output/C-CDA_R2-1_CCD-w-provenance.xml";
@@ -153,12 +153,12 @@ public class ValidatorTest {
 				generateDAFProfileMetadata, false);
 	}
 
-	// Vitera_CCDA_SMART_Sample.xml with profile
-	@Ignore
+	// HannahBanana_EpicCCD.xml
+	@Test
 	public void testRakiaBundle() throws Exception {
-		String cdaResourcePath = "src/test/resources/Cerner/Person-RAKIA_TEST_DOC00001 (1).XML";
-		String targetPathForFHIRResource = "src/test/resources/output/Cerner/Person-RAKIA_TEST_DOC00001 (1).fhir.xml";
-		String targetPathForResultFile = "src/test/resources/output/Cerner/validation-result-Person-RAKIA_TEST_DOC00001 (1).html";
+		String cdaResourcePath = "src/test/resources/Epic/HannahBanana_EpicCCD-pretty.xml";
+		String targetPathForFHIRResource = "src/test/resources/output/Epic/HannahBanana_EpicCCD-pretty.fhir.xml";
+		String targetPathForResultFile = "src/test/resources/output/Cerner/HannahBanana_EpicCCD-pretty.validation-result.html";
 		boolean generateDAFProfileMetadata = true;
 		transformAndValidate(cdaResourcePath, targetPathForFHIRResource, targetPathForResultFile,
 				generateDAFProfileMetadata, false);

--- a/src/test/java/tr/com/srdc/cda2fhir/ValidatorTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/ValidatorTest.java
@@ -155,7 +155,7 @@ public class ValidatorTest {
 
 	// HannahBanana_EpicCCD.xml
 	@Test
-	public void testRakiaBundle() throws Exception {
+	public void testHannahBanana() throws Exception {
 		String cdaResourcePath = "src/test/resources/Epic/HannahBanana_EpicCCD-pretty.xml";
 		String targetPathForFHIRResource = "src/test/resources/output/Epic/HannahBanana_EpicCCD-pretty.fhir.xml";
 		String targetPathForResultFile = "src/test/resources/output/Cerner/HannahBanana_EpicCCD-pretty.validation-result.html";

--- a/src/test/java/tr/com/srdc/cda2fhir/ValidatorTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/ValidatorTest.java
@@ -99,7 +99,7 @@ public class ValidatorTest {
 	}
 
 	// C-CDA_R2-1_CCD.xml without DAF profile
-	@Ignore
+	@Test
 	public void testReferenceCCDBundleWithoutProfile() throws Exception {
 		String cdaResourcePath = "src/test/resources/C-CDA_R2-1_CCD.xml";
 		String targetPathForFHIRResource = "src/test/resources/output/C-CDA_R2-1_CCD-wo-profile-validation.xml";
@@ -110,7 +110,7 @@ public class ValidatorTest {
 	}
 
 	// C-CDA_R2-1_CCD.xml with provenance
-	@Ignore
+	@Test
 	public void testReferenceCCDBundleWithProvenance() throws Exception {
 		String cdaResourcePath = "src/test/resources/C-CDA_R2-1_CCD.xml";
 		String targetPathForFHIRResource = "src/test/resources/output/C-CDA_R2-1_CCD-w-provenance.xml";
@@ -153,12 +153,12 @@ public class ValidatorTest {
 				generateDAFProfileMetadata, false);
 	}
 
-	// HannahBanana_EpicCCD.xml
-	@Test
+	// Vitera_CCDA_SMART_Sample.xml with profile
+	@Ignore
 	public void testRakiaBundle() throws Exception {
-		String cdaResourcePath = "src/test/resources/Epic/HannahBanana_EpicCCD-pretty.xml";
-		String targetPathForFHIRResource = "src/test/resources/output/Epic/HannahBanana_EpicCCD-pretty.fhir.xml";
-		String targetPathForResultFile = "src/test/resources/output/Cerner/HannahBanana_EpicCCD-pretty.validation-result.html";
+		String cdaResourcePath = "src/test/resources/Cerner/Person-RAKIA_TEST_DOC00001 (1).XML";
+		String targetPathForFHIRResource = "src/test/resources/output/Cerner/Person-RAKIA_TEST_DOC00001 (1).fhir.xml";
+		String targetPathForResultFile = "src/test/resources/output/Cerner/validation-result-Person-RAKIA_TEST_DOC00001 (1).html";
 		boolean generateDAFProfileMetadata = true;
 		transformAndValidate(cdaResourcePath, targetPathForFHIRResource, targetPathForResultFile,
 				generateDAFProfileMetadata, false);

--- a/src/test/java/tr/com/srdc/cda2fhir/ValidatorTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/ValidatorTest.java
@@ -30,7 +30,6 @@ import org.hl7.fhir.dstu3.model.Identifier;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
-import org.junit.Test;
 import org.openhealthtools.mdht.uml.cda.consol.ConsolPackage;
 import org.openhealthtools.mdht.uml.cda.consol.ContinuityOfCareDocument;
 import org.openhealthtools.mdht.uml.cda.util.CDAUtil;
@@ -154,11 +153,22 @@ public class ValidatorTest {
 	}
 
 	// HannahBanana_EpicCCD.xml
-	@Test
+	@Ignore
 	public void testHannahBanana() throws Exception {
 		String cdaResourcePath = "src/test/resources/Epic/HannahBanana_EpicCCD-pretty.xml";
 		String targetPathForFHIRResource = "src/test/resources/output/Epic/HannahBanana_EpicCCD-pretty.fhir.xml";
 		String targetPathForResultFile = "src/test/resources/output/Cerner/HannahBanana_EpicCCD-pretty.validation-result.html";
+		boolean generateDAFProfileMetadata = true;
+		transformAndValidate(cdaResourcePath, targetPathForFHIRResource, targetPathForResultFile,
+				generateDAFProfileMetadata, false);
+	}
+
+	// Person-RAKIA_TEST_DOC0001 (1).xml
+	@Ignore
+	public void testHannahBanana() throws Exception {
+		String cdaResourcePath = "src/test/resources/Cerner/Person-RAKIA_TEST_DOC00001 (1).xml";
+		String targetPathForFHIRResource = "src/test/resources/output/Epic/Person-RAKIA_TEST_DOC00001 (1).fhir.xml";
+		String targetPathForResultFile = "src/test/resources/output/Cerner/Person-RAKIA_TEST_DOC00001 (1).validation-result.html";
 		boolean generateDAFProfileMetadata = true;
 		transformAndValidate(cdaResourcePath, targetPathForFHIRResource, targetPathForResultFile,
 				generateDAFProfileMetadata, false);

--- a/src/test/java/tr/com/srdc/cda2fhir/ValidatorTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/ValidatorTest.java
@@ -165,7 +165,7 @@ public class ValidatorTest {
 
 	// Person-RAKIA_TEST_DOC0001 (1).xml
 	@Ignore
-	public void testHannahBanana() throws Exception {
+	public void testRakia() throws Exception {
 		String cdaResourcePath = "src/test/resources/Cerner/Person-RAKIA_TEST_DOC00001 (1).xml";
 		String targetPathForFHIRResource = "src/test/resources/output/Epic/Person-RAKIA_TEST_DOC00001 (1).fhir.xml";
 		String targetPathForResultFile = "src/test/resources/output/Cerner/Person-RAKIA_TEST_DOC00001 (1).validation-result.html";


### PR DESCRIPTION
#### What does this PR do?

Updates the EMF util to return additional sections, and adds in support for the 'text' object on Immunizations. You have to pass the bundleContext into the function to get it to work through, so we can open another ticket to go through and add that parameter pass into each function to support originalText where appropriate, this is just for Immz.

#### Related JIRA tickets:

[UPMCFHIR-270](https://jira.amida.com/browse/UPMCFHIR-270)

#### How should this be manually tested?

Look at the file and see if there is a text field there now for Immz encoding.

#### Background/Context:

Need to preserve original text in parsing some fields that aren't encoded well in Epic.

#### New JIRA tickets for clinical review required?

No