### PR TITLE
Feature/upmcfhir 305 306 jf sort process files

### DIFF
--- a/src/main/java/tr/com/srdc/cda2fhir/util/FHIRUtil.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/util/FHIRUtil.java
@@ -97,16 +97,18 @@ public class FHIRUtil {
 		}
 	}
 
-	public static <T extends IBaseResource> void printJSON(Collection<T> resources, String filePath) {
+	public static <T extends IBaseResource> void printJSON(Collection<T> resources, String filePath)
+			throws IOException {
 		File f = new File(filePath);
 		f.getParentFile().mkdirs();
+		FileWriter fw = new FileWriter(f);
 		try {
 			String json = encodeToJSON(resources);
-			FileWriter fw = new FileWriter(f);
 			fw.write(json);
-			fw.close();
 		} catch (IOException e) {
 			logger.error("Could not print FHIR JSON to file", e);
+		} finally {
+			fw.close();
 		}
 	}
 

--- a/src/main/java/tr/com/srdc/cda2fhir/util/FHIRUtil.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/util/FHIRUtil.java
@@ -83,17 +83,17 @@ public class FHIRUtil {
 	public static void printJSON(IBaseResource res, String filePath) throws IOException {
 		File f = new File(filePath);
 		f.getParentFile().mkdirs();
+		FileWriter fw = new FileWriter(f);
 		try {
-			FileWriter fw = new FileWriter(f);
 			jsonParser.encodeResourceToWriter(res, fw);
-			fw.close();
-
 		} catch (IOException ie) {
 			logger.error("Could not print FHIR JSON to file", ie);
 			throw new IOException(ie);
 		} catch (DataFormatException de) {
 			logger.error("Could not print FHIR JSON to file", de);
 			throw new DataFormatException(de);
+		} finally {
+			fw.close();
 		}
 	}
 

--- a/src/main/java/tr/com/srdc/cda2fhir/util/FHIRUtil.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/util/FHIRUtil.java
@@ -112,13 +112,16 @@ public class FHIRUtil {
 		}
 	}
 
-	public static void printXML(IBaseResource res, String filePath) {
+	public static void printXML(IBaseResource res, String filePath) throws IOException {
 		File f = new File(filePath);
 		f.getParentFile().mkdirs();
+		FileWriter fw = new FileWriter(f);
 		try {
-			xmlParser.encodeResourceToWriter(res, new FileWriter(f));
+			xmlParser.encodeResourceToWriter(res, fw);
 		} catch (IOException e) {
 			logger.error("Could not print FHIR XML to file", e);
+		} finally {
+			fw.close();
 		}
 	}
 

--- a/src/main/java/tr/com/srdc/cda2fhir/util/FHIRUtil.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/util/FHIRUtil.java
@@ -37,6 +37,7 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import ca.uhn.fhir.parser.DataFormatException;
 import ca.uhn.fhir.parser.IParser;
 import tr.com.srdc.cda2fhir.conf.Config;
 
@@ -79,13 +80,17 @@ public class FHIRUtil {
 		System.out.println(xmlParser.encodeResourceToString(res));
 	}
 
-	public static void printJSON(IBaseResource res, String filePath) {
+	public static void printJSON(IBaseResource res, String filePath) throws IOException {
 		File f = new File(filePath);
 		f.getParentFile().mkdirs();
 		try {
 			jsonParser.encodeResourceToWriter(res, new FileWriter(f));
-		} catch (IOException e) {
-			logger.error("Could not print FHIR JSON to file", e);
+		} catch (IOException ie) {
+			logger.error("Could not print FHIR JSON to file", ie);
+			throw new IOException(ie);
+		} catch (DataFormatException de) {
+			logger.error("Could not print FHIR JSON to file", de);
+			throw new DataFormatException(de);
 		}
 	}
 

--- a/src/main/java/tr/com/srdc/cda2fhir/util/FHIRUtil.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/util/FHIRUtil.java
@@ -84,7 +84,10 @@ public class FHIRUtil {
 		File f = new File(filePath);
 		f.getParentFile().mkdirs();
 		try {
-			jsonParser.encodeResourceToWriter(res, new FileWriter(f));
+			FileWriter fw = new FileWriter(f);
+			jsonParser.encodeResourceToWriter(res, fw);
+			fw.close();
+
 		} catch (IOException ie) {
 			logger.error("Could not print FHIR JSON to file", ie);
 			throw new IOException(ie);

--- a/src/main/java/tr/com/srdc/cda2fhir/util/FHIRUtil.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/util/FHIRUtil.java
@@ -83,8 +83,9 @@ public class FHIRUtil {
 	public static void printJSON(IBaseResource res, String filePath) throws IOException {
 		File f = new File(filePath);
 		f.getParentFile().mkdirs();
-		FileWriter fw = new FileWriter(f);
+		FileWriter fw = null;
 		try {
+			fw = new FileWriter(f);
 			jsonParser.encodeResourceToWriter(res, fw);
 		} catch (IOException ie) {
 			logger.error("Could not print FHIR JSON to file", ie);
@@ -93,7 +94,13 @@ public class FHIRUtil {
 			logger.error("Could not print FHIR JSON to file", de);
 			throw new DataFormatException(de);
 		} finally {
-			fw.close();
+			if (fw != null) {
+				try {
+					fw.close();
+				} catch (IOException ie) {
+					logger.error("Could not close writer for function \"printJSON.\" with IBaseResource.");
+				}
+			}
 		}
 	}
 
@@ -101,27 +108,41 @@ public class FHIRUtil {
 			throws IOException {
 		File f = new File(filePath);
 		f.getParentFile().mkdirs();
-		FileWriter fw = new FileWriter(f);
+		FileWriter fw = null;
 		try {
+			fw = new FileWriter(f);
 			String json = encodeToJSON(resources);
 			fw.write(json);
 		} catch (IOException e) {
 			logger.error("Could not print FHIR JSON to file", e);
 		} finally {
-			fw.close();
+			if (fw != null) {
+				try {
+					fw.close();
+				} catch (IOException ie) {
+					logger.error("Could not close writer for function \"printJSON.\" with Collection.");
+				}
+			}
 		}
 	}
 
 	public static void printXML(IBaseResource res, String filePath) throws IOException {
 		File f = new File(filePath);
 		f.getParentFile().mkdirs();
-		FileWriter fw = new FileWriter(f);
+		FileWriter fw = null;
 		try {
+			fw = new FileWriter(f);
 			xmlParser.encodeResourceToWriter(res, fw);
 		} catch (IOException e) {
 			logger.error("Could not print FHIR XML to file", e);
 		} finally {
-			fw.close();
+			if (fw != null) {
+				try {
+					fw.close();
+				} catch (IOException ie) {
+					logger.error("Could not close writer for function \"printJSON.\" with Collection.");
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
#### What does this PR do?
1) Throws an `IOException` if the JSONParser writing fails. This allows Higgs to pick up failure.
2) Closes the `FileWriter` which was locking files.

#### Related JIRA tickets:
UPMCFHIR-305
UPMCFHIR-306

#### How should this be manually tested?
Run the unit tests I suppose.

#### Background/Context:
The locking files was throwing the results for unit tests on Higgs because I could not delete created files and folders. The lock was blocking even the `FileUtils.forceDelete()` function. 

#### New JIRA tickets for clinical review required?
