### PR TITLE
flip clinical status to inactive, and drop verification status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ valOutcomeOs.close();
 fos.close();
 ```
 
-Further examples can be found in [ValidatorTest](https://github.com/srdc/cda2fhir/blob/master/src/test/java/tr/com/srdc/cda2fhir/ValidatorTest.java) class.
+Further examples can be found in [ValidatorTest](https://github.com/srdc/cda2fhir/blob/master/src/test/java/tr/com/srdc/cda2fhir/ValidatorTest.java) class
 
 ## Acknowledgement
 

--- a/src/main/java/tr/com/srdc/cda2fhir/jolt/AdditionalModifier.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/jolt/AdditionalModifier.java
@@ -392,7 +392,7 @@ public class AdditionalModifier implements SpecDriven, ContextualTransform {
 				return null;
 			}
 			if (argList.indexOf("high") >= 0 && argList.indexOf("low") >= 0) {
-				return Optional.of("resolved");
+				return Optional.of("inactive");
 			}
 			if (argList.indexOf("value") >= 0 || argList.indexOf("low") >= 0) {
 				return Optional.of("active");

--- a/src/main/java/tr/com/srdc/cda2fhir/jolt/IndicationClinicalStatus.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/jolt/IndicationClinicalStatus.java
@@ -27,7 +27,7 @@ public class IndicationClinicalStatus implements ContextualTransform, IRootNodeU
 		INode highNode = nodes.get("#high");
 		INode valueNode = nodes.get("#value");
 
-		highNode.setPath("#resolved");
+		highNode.setPath("#inactive");
 		IParentNode highParent = highNode.getParent();
 		IParentNode newBaseHigh = highParent.separateChildLines("#high").get(0);
 		newBaseHigh.copyConditions(lowNode);
@@ -60,7 +60,7 @@ public class IndicationClinicalStatus implements ContextualTransform, IRootNodeU
 		}
 		List<Object> list = (List<Object>) clinicalStatus;
 		if (list.indexOf("high") >= 0 && list.indexOf("low") >= 0) {
-			inputAsMap.put("clinicalStatus", "resolved");
+			inputAsMap.put("clinicalStatus", "inactive");
 			return input;
 		}
 		if (list.indexOf("value") >= 0 || list.indexOf("low") >= 0) {

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
@@ -1858,12 +1858,12 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 
 		// effectiveTime info -> clinicalStatus
 		if (cdaIndication.getEffectiveTime() != null && !cdaIndication.getEffectiveTime().isSetNullFlavor()) {
-			// high & low is present -> resolved
+			// high & low is present -> inactive
 			if (cdaIndication.getEffectiveTime().getLow() != null
 					&& !cdaIndication.getEffectiveTime().getLow().isSetNullFlavor()
 					&& cdaIndication.getEffectiveTime().getHigh() != null
 					&& !cdaIndication.getEffectiveTime().getHigh().isSetNullFlavor()) {
-				fhirCond.setClinicalStatus(ConditionClinicalStatus.RESOLVED);
+				fhirCond.setClinicalStatus(ConditionClinicalStatus.INACTIVE);
 			} else if (cdaIndication.getEffectiveTime().getLow() != null
 					&& !cdaIndication.getEffectiveTime().getLow().isSetNullFlavor()) {
 				// low is present, high is not present -> active
@@ -1885,14 +1885,6 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 			}
 		}
 
-		// only set verificationStatus if clinicalStatus is present.
-		if (fhirCond.getClinicalStatus() != null) {
-			CS statusCode = cdaIndication.getStatusCode();
-			String statusCodeValue = statusCode == null || statusCode.isSetNullFlavor() ? null : statusCode.getCode();
-
-			// statusCode -> verificationStatus
-			fhirCond.setVerificationStatus(vst.tStatusCode2ConditionVerificationStatus(statusCodeValue));
-		}
 		return fhirCond;
 	}
 

--- a/src/test/java/tr/com/srdc/cda2fhir/ValidatorTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/ValidatorTest.java
@@ -154,7 +154,7 @@ public class ValidatorTest {
 	}
 
 	// HannahBanana_EpicCCD.xml
-	@Test
+	@Ignore
 	public void testHannahBanana() throws Exception {
 		String cdaResourcePath = "src/test/resources/Epic/HannahBanana_EpicCCD-pretty.xml";
 		String targetPathForFHIRResource = "src/test/resources/output/Epic/HannahBanana_EpicCCD-pretty.fhir.xml";
@@ -165,7 +165,7 @@ public class ValidatorTest {
 	}
 
 	// Person-RAKIA_TEST_DOC0001 (1).xml
-	@Test
+	@Ignore
 	public void testRakia() throws Exception {
 		String cdaResourcePath = "src/test/resources/Cerner/Person-RAKIA_TEST_DOC00001 (1).xml";
 		String targetPathForFHIRResource = "src/test/resources/output/Cerner/Person-RAKIA_TEST_DOC00001 (1).fhir.xml";

--- a/src/test/java/tr/com/srdc/cda2fhir/ValidatorTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/ValidatorTest.java
@@ -154,7 +154,7 @@ public class ValidatorTest {
 	}
 
 	// HannahBanana_EpicCCD.xml
-	@Ignore
+	@Test
 	public void testHannahBanana() throws Exception {
 		String cdaResourcePath = "src/test/resources/Epic/HannahBanana_EpicCCD-pretty.xml";
 		String targetPathForFHIRResource = "src/test/resources/output/Epic/HannahBanana_EpicCCD-pretty.fhir.xml";
@@ -165,7 +165,7 @@ public class ValidatorTest {
 	}
 
 	// Person-RAKIA_TEST_DOC0001 (1).xml
-	@Ignore
+	@Test
 	public void testRakia() throws Exception {
 		String cdaResourcePath = "src/test/resources/Cerner/Person-RAKIA_TEST_DOC00001 (1).xml";
 		String targetPathForFHIRResource = "src/test/resources/output/Cerner/Person-RAKIA_TEST_DOC00001 (1).fhir.xml";

--- a/src/test/java/tr/com/srdc/cda2fhir/testutil/generator/EffectiveTimeGenerator.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/testutil/generator/EffectiveTimeGenerator.java
@@ -28,7 +28,7 @@ public class EffectiveTimeGenerator {
 	}
 
 	public EffectiveTimeGenerator(String lowValue, String highValue) {
-		this.lowNullFlavor = lowValue;
+		this.lowValue = lowValue;
 		this.highValue = highValue;
 	}
 

--- a/src/test/java/tr/com/srdc/cda2fhir/testutil/generator/IndicationGenerator.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/testutil/generator/IndicationGenerator.java
@@ -50,6 +50,7 @@ public class IndicationGenerator {
 		});
 
 		if (effectiveTimeGenerator != null) {
+
 			IVL_TS ivlTs = effectiveTimeGenerator.generate(factories);
 			indication.setEffectiveTime(ivlTs);
 		}
@@ -74,7 +75,7 @@ public class IndicationGenerator {
 		indication.idGenerators.add(IDGenerator.getNextInstance());
 		indication.code = "75321-0";
 		indication.valueGenerators.add(CDGenerator.getNextInstance());
-		indication.effectiveTimeGenerator = new EffectiveTimeGenerator("20171008");
+		indication.effectiveTimeGenerator = new EffectiveTimeGenerator("20171008", "20190110");
 		indication.statusCode = "active";
 
 		return indication;

--- a/src/test/java/tr/com/srdc/cda2fhir/testutil/generator/IndicationGenerator.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/testutil/generator/IndicationGenerator.java
@@ -2,7 +2,6 @@ package tr.com.srdc.cda2fhir.testutil.generator;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.Condition;
@@ -13,14 +12,10 @@ import org.openhealthtools.mdht.uml.hl7.datatypes.CS;
 import org.openhealthtools.mdht.uml.hl7.datatypes.II;
 import org.openhealthtools.mdht.uml.hl7.datatypes.IVL_TS;
 
-import com.bazaarvoice.jolt.JsonUtils;
-
 import tr.com.srdc.cda2fhir.testutil.CDAFactories;
 import tr.com.srdc.cda2fhir.util.FHIRUtil;
 
 public class IndicationGenerator {
-	private static final Map<String, Object> CONDITION_VERIFICATION_STATUS = JsonUtils
-			.filepathToMap("src/test/resources/jolt/value-maps/ConditionVerificationStatus.json");
 
 	private List<IDGenerator> idGenerators = new ArrayList<>();
 
@@ -126,14 +121,5 @@ public class IndicationGenerator {
 			}
 		}
 
-		if (statusCode == null) {
-			Assert.assertEquals("Condition verification status", "unknown", condition.getVerificationStatus().toCode());
-		} else {
-			String actual = (String) CONDITION_VERIFICATION_STATUS.get(statusCode);
-			if (actual == null) {
-				actual = "unknown";
-			}
-			Assert.assertEquals("Condition verification status", actual, condition.getVerificationStatus().toCode());
-		}
 	}
 }

--- a/src/test/resources/gold/jolt-report/Indication.csv
+++ b/src/test/resources/gold/jolt-report/Indication.csv
@@ -8,4 +8,3 @@ observation.value[],Condition.code,CD,,nullFlavor isnull
 observation.id[],Condition.identifier[],ID,,nullFlavor isnull
 observation.effectiveTime.low.value,Condition.onsetDateTime,,"datetimeAdapter",nullFlavor isnull,observation.effectiveTime.low.nullFlavor isnull,observation.effectiveTime.nullFlavor isnull
 observation.effectiveTime.value,Condition.onsetDateTime,,"datetimeAdapter",nullFlavor isnull,observation.effectiveTime.low isnull or observation.effectiveTime.low.nullFlavor isnotnull,observation.effectiveTime.nullFlavor isnull
-observation.statusCode.code,Condition.verificationStatus,,"valueSetAdapter('ConditionVerificationStatus','unknown')",nullFlavor isnull

--- a/src/test/resources/gold/jolt-report/MedIndication.csv
+++ b/src/test/resources/gold/jolt-report/MedIndication.csv
@@ -8,4 +8,3 @@ observation.value[],Condition.code,CD,,nullFlavor isnull
 observation.id[],Condition.identifier[],ID,,nullFlavor isnull
 observation.effectiveTime.low.value,Condition.onsetDateTime,,"datetimeAdapter",nullFlavor isnull,observation.effectiveTime.low.nullFlavor isnull,observation.effectiveTime.nullFlavor isnull
 observation.effectiveTime.value,Condition.onsetDateTime,,"datetimeAdapter",nullFlavor isnull,observation.effectiveTime.low isnull or observation.effectiveTime.low.nullFlavor isnotnull,observation.effectiveTime.nullFlavor isnull
-observation.statusCode.code,Condition.verificationStatus,,"valueSetAdapter('ConditionVerificationStatus','unknown')",nullFlavor isnull

--- a/src/test/resources/jolt-verify/intermediate/IndicationEffectiveTime.json
+++ b/src/test/resources/jolt-verify/intermediate/IndicationEffectiveTime.json
@@ -56,7 +56,7 @@
 		"expected": {
 			"abatementDateTime": "20190507",
 			"onsetDateTime": "20180311",
-			"clinicalStatus": "resolved"
+			"clinicalStatus": "inactive"
 		}
 	},
 	{
@@ -84,7 +84,7 @@
 		"expected": {
 			"abatementDateTime": "20190507",
 			"onsetDateTime": "20180311",
-			"clinicalStatus": "resolved"
+			"clinicalStatus": "inactive"
 		}
 	},
 	{

--- a/src/test/resources/jolt/entry/Indication.json
+++ b/src/test/resources/jolt/entry/Indication.json
@@ -36,6 +36,7 @@
 	{
 		"operation": "tr.com.srdc.cda2fhir.jolt.AdditionalModifier",
 		"spec": {
+			"clinicalStatus": "=ConditionClinicalStatusAdapter(@0)",
 			"category": {
 				"*": "=constantValue('EncounterConditionCategoryConstant')"
 			},

--- a/src/test/resources/jolt/entry/Indication.json
+++ b/src/test/resources/jolt/entry/Indication.json
@@ -26,10 +26,7 @@
 				"value": {
 					"*": "code.->CD"
 				},
-				"effectiveTime": "->IndicationEffectiveTime",
-				"statusCode": {
-					"code": "verificationStatus"
-				}
+				"effectiveTime": "->IndicationEffectiveTime"
 			}
 		}
 	},
@@ -39,7 +36,6 @@
 	{
 		"operation": "tr.com.srdc.cda2fhir.jolt.AdditionalModifier",
 		"spec": {
-			"verificationStatus": "=valueSetAdapter('ConditionVerificationStatus','unknown',@0)",
 			"category": {
 				"*": "=constantValue('EncounterConditionCategoryConstant')"
 			},

--- a/src/test/resources/jolt/entry/MedIndication.json
+++ b/src/test/resources/jolt/entry/MedIndication.json
@@ -26,10 +26,7 @@
 				"value": {
 					"*": "code.->CD"
 				},
-				"effectiveTime": "->IndicationEffectiveTime",
-				"statusCode": {
-					"code": "verificationStatus"
-				}
+				"effectiveTime": "->IndicationEffectiveTime"
 			}
 		}
 	},
@@ -39,7 +36,6 @@
 	{
 		"operation": "tr.com.srdc.cda2fhir.jolt.AdditionalModifier",
 		"spec": {
-			"verificationStatus": "=valueSetAdapter('ConditionVerificationStatus','unknown',@0)",
 			"category": {
 				"*": "=constantValue('MedicationConditionCategoryConstant')"
 			},


### PR DESCRIPTION
#### What does this PR do?

It occurred to me that we never actually evaluated tIndication2Condition for migration to STU3, we were just sort of using it. In looking at it, 2 things stood out:

1 - We were making date assertions to set the clinical status to 'resolved' instead of 'inactive'. Resolved is assertively saying the problem is done for good, and inactive is just saying it is not longer active, so I adjusted this.

2 - We were setting verification status by using the tStatusCode2ConditionVerificationStatus function. This didn't really work, because problem status is hard set to "completed" on indications, which would have always resulted in a "refuted" verification status for every indication. Rather than make an assertion either way, I backed out verification status logic since it is an optional field on the mapping.

#### Related JIRA tickets:

[UPMCFHIR-327](https://jira.amida.com/browse/UPMCFHIR-327)

#### How should this be manually tested?

Run the tests, Jolt should be fixed too.

#### Background/Context:

#### New JIRA tickets for clinical review required?
